### PR TITLE
Resolves #44: Acceptance tests for events creation, deletion and update

### DIFF
--- a/src/main/java/AcceptanceTest/users/AllTestRun.java
+++ b/src/main/java/AcceptanceTest/users/AllTestRun.java
@@ -2,8 +2,10 @@ package AcceptanceTest.users;
 
 
 import AcceptanceTest.users.CompanyManagementTest.CompanyManagementTest;
+import AcceptanceTest.users.EventManagementTest.EventManagementTest;
 import AcceptanceTest.users.visitorTests.UserActionInfo;
 import Appliction.CompanyService;
+import Appliction.EventService;
 import Appliction.IPasswordEncoder;
 import Appliction.UserService;
 import Domain.Company.iCompanyRepository;
@@ -15,7 +17,7 @@ import Infastructure.*;
 public class AllTestRun {
     private UserActionInfo visitorActionTest;
     private CompanyManagementTest companyManagementTest;
-
+    private EventManagementTest eventManagementTest;
 
 //    private AdminTests adminTests;
     public AllTestRun() {
@@ -29,11 +31,12 @@ public class AllTestRun {
 
         UserService userService=new UserService(iPasswordEncoder,iUserRepository,tokenService);
         CompanyService companyService=new CompanyService(iCompanyRepository,iUserRepository,iTreeOfRoleRepository,tokenService);
-
+        EventService eventService = new EventService();
 
         visitorActionTest = new UserActionInfo(userService,initTheSystem);
         companyManagementTest=new CompanyManagementTest(companyService,userService,initTheSystem);
-
+        eventManagementTest = new EventManagementTest(userService, eventService, initTheSystem);
+        
     }
     public void runAllTests() {
         System.out.println("Visitor action test ");
@@ -41,13 +44,16 @@ public class AllTestRun {
         String visitorActionTestResultsFailed=visitorActionTest.SeeFailTest();
         String CompanyActionTestResults=companyManagementTest.whichTestPass();
         String CompanyActionTestResultsFailed=companyManagementTest.SeeFailTest();
-
+        String eventTestResults = eventManagementTest.runAllTests();
 
         System.out.println(visitorActionTestResults);
         System.out.println(visitorActionTestResultsFailed);
+        System.out.println("-------------------------------------------------");
         System.out.println(CompanyActionTestResults);
         System.out.println(CompanyActionTestResultsFailed);
-
+        System.out.println("-------------------------------------------------");
+        System.out.println(eventTestResults);
+        
 
     }
 }

--- a/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
+++ b/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
@@ -5,7 +5,10 @@ import Appliction.UserService;
 import Appliction.EventService;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 public class EventManagementTest {
     
@@ -15,35 +18,59 @@ public class EventManagementTest {
     
     private final List<String> failTests = new ArrayList<>();
     private final List<String> passTests = new ArrayList<>();
+    private final Map<String, Supplier<Boolean>> testMap = new LinkedHashMap<>();
 
     public EventManagementTest(UserService userService, EventService eventService, initTheSystem initTheSystem) {
         this.userService = userService;
         this.eventService = eventService;
         this.initTheSystem = initTheSystem;
+        initTestMap();
+    }
+
+    private void initTestMap() {
+        testMap.put("1", this::fullEventLifecycleTest);
+        testMap.put("2", this::createEventFailedNoToken);
+        testMap.put("3", this::createEventFailedMissingFields);
+        testMap.put("4", this::updateEventSuccess);
+        testMap.put("5", this::updateNonExistentEventTest);
+        testMap.put("6", this::updateEventFailedNoPermission);
+        testMap.put("7", this::deleteEventSuccess);
+        testMap.put("8", this::deleteEventWithoutPermissionsTest);
+        testMap.put("9", this::deleteNonExistentEventTest);
+        testMap.put("10", this::createEventFailedPastDate);
+        testMap.put("11", this::createEventFailedInvalidDateFormat);
+        testMap.put("12", this::updateEventNameSuccess);
+        testMap.put("13", this::updateEventNameFailedNoPermission);
+        testMap.put("14", this::updateEventLocationSuccess);
+        testMap.put("15", this::deleteEventTwiceFailed);
+        testMap.put("16", this::getEventInfoSuccess);
+        testMap.put("17", this::getEventInfoFailedNotExist);
     }
 
     public String runAllTests() {
-        StringBuilder results = new StringBuilder();
-        results.append("Event Management Acceptance Tests:\n");
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("Event Management Acceptance Tests:\n");
 
-        runTest("1", "Full Cycle: Create, Update, and Delete Event", this::fullEventLifecycleTest, results);
-        runTest("2", "Fail to Update Event That Does Not Exist", this::updateNonExistentEventTest, results);
-        runTest("3", "Fail to Delete Event Without Permissions", this::deleteEventWithoutPermissionsTest, results);
+        testMap.forEach((id, testLogic) -> {
+            initTheSystem.init(); 
+            
+            boolean result;
+            try {
+                result = testLogic.get();
+            } catch (Exception e) {
+                result = false;
+            }
 
-        return results.toString();
-    }
+            stringBuilder.append("the result of test ").append(id).append(": ").append(result).append("\n");
 
-    private void runTest(String testId, String description, java.util.function.Supplier<Boolean> testLogic, StringBuilder results) {
-        initTheSystem.init(); 
-        boolean result;
-        try {
-            result = testLogic.get();
-        } catch (Exception e) {
-            result = false;
-        }
+            if (result) {
+                passTests.add(id);
+            } else {
+                failTests.add(id);
+            }
+        });
 
-        results.append("Test ").append(testId).append(" - ").append(description).append(": ").append(result ? "PASS" : "FAIL").append("\n");
-        if (result) passTests.add(testId); else failTests.add(testId);
+        return stringBuilder.toString();
     }
 
     public boolean fullEventLifecycleTest() {
@@ -51,22 +78,37 @@ public class EventManagementTest {
         String token = userService.login("adminUser", "password123");
 
         String eventId = eventService.createEvent("Shlomo Artzi Concert", "2026-08-15", "Caesarea", token);
-        if (eventId == null || eventId.isEmpty() || eventId.equals("failed")) {
-            return false;
-        }
+        if (eventId == null || eventId.isEmpty() || eventId.equals("failed")) return false;
 
         String updateResult = eventService.updateEventDate(eventId, "2026-08-16", token);
-        if (!updateResult.equals("success")) {
-            return false;
-        }
+        if (!updateResult.equals("success")) return false;
 
         String deleteResult = eventService.deleteEvent(eventId, token);
-        if (!deleteResult.equals("success")) {
-            return false;
-        }
+        if (!deleteResult.equals("success")) return false;
 
         String getEventResult = eventService.getEventInfo(eventId);
         return getEventResult.equals("failed_not_found");
+    }
+
+    public boolean createEventFailedNoToken() {
+        String result = eventService.createEvent("Coldplay Live", "2026-09-01", "Park Hayarkon", "");
+        return result.equals("failed");
+    }
+
+    public boolean createEventFailedMissingFields() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String result = eventService.createEvent("", "", "Tel Aviv", token);
+        return result.equals("failed");
+    }
+
+    public boolean updateEventSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Jazz Festival", "2026-05-05", "Jerusalem", token);
+        
+        String result = eventService.updateEventDate(eventId, "2026-05-06", token);
+        return result.equals("success");
     }
 
     public boolean updateNonExistentEventTest() {
@@ -75,6 +117,27 @@ public class EventManagementTest {
         
         String result = eventService.updateEventDate("fake-id-999", "2026-10-10", token);
         return result.equals("failed");
+    }
+
+    public boolean updateEventFailedNoPermission() {
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken);
+
+        userService.register("hacker", "hackerPass");
+        String hackerToken = userService.login("hacker", "hackerPass");
+        
+        String updateResult = eventService.updateEventDate(eventId, "2026-01-02", hackerToken);
+        return updateResult.equals("failed_no_permission");
+    }
+
+    public boolean deleteEventSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Tech Conference", "2026-11-11", "Expo TLV", token);
+        
+        String result = eventService.deleteEvent(eventId, token);
+        return result.equals("success");
     }
 
     public boolean deleteEventWithoutPermissionsTest() {
@@ -87,5 +150,76 @@ public class EventManagementTest {
         
         String deleteResult = eventService.deleteEvent(eventId, hackerToken);
         return deleteResult.equals("failed_no_permission");
+    }
+
+    public boolean deleteNonExistentEventTest() {
+        userService.register("user1", "pass");
+        String token = userService.login("user1", "pass");
+        
+        String result = eventService.deleteEvent("fake-id-999", token);
+        return result.equals("failed");
+    }
+
+    public boolean createEventFailedPastDate() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String result = eventService.createEvent("Old Event", "2020-01-01", "Haifa", token);
+        return result.equals("failed");
+    }
+
+    public boolean createEventFailedInvalidDateFormat() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String result = eventService.createEvent("Bad Date Event", "invalid-date", "Eilat", token);
+        return result.equals("failed");
+    }
+
+    public boolean updateEventNameSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Initial Name", "2026-08-15", "Caesarea", token);
+        String result = eventService.updateEventName(eventId, "Updated Name", token);
+        return result.equals("success");
+    }
+
+    public boolean updateEventNameFailedNoPermission() {
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("My Event", "2026-01-01", "Tel Aviv", adminToken);
+
+        userService.register("user2", "pass2");
+        String userToken = userService.login("user2", "pass2");
+        String result = eventService.updateEventName(eventId, "Hacked Name", userToken);
+        return result.equals("failed_no_permission");
+    }
+
+    public boolean updateEventLocationSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Moving Event", "2026-08-15", "Haifa", token);
+        String result = eventService.updateEventLocation(eventId, "Tel Aviv", token);
+        return result.equals("success");
+    }
+
+    public boolean deleteEventTwiceFailed() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Double Delete", "2026-11-11", "Expo TLV", token);
+        eventService.deleteEvent(eventId, token);
+        String result = eventService.deleteEvent(eventId, token);
+        return result.equals("failed_already_deleted");
+    }
+
+    public boolean getEventInfoSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Info Event", "2026-12-12", "Eilat", token);
+        String result = eventService.getEventInfo(eventId);
+        return !result.equals("failed_not_found") && !result.isEmpty();
+    }
+
+    public boolean getEventInfoFailedNotExist() {
+        String result = eventService.getEventInfo("fake-id-999");
+        return result.equals("failed_not_found");
     }
 }

--- a/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
+++ b/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
@@ -1,0 +1,91 @@
+package AcceptanceTest.users.EventManagementTest;
+
+import AcceptanceTest.users.initTheSystem;
+import Appliction.UserService;
+import Appliction.EventService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventManagementTest {
+    
+    private UserService userService;
+    private EventService eventService; 
+    private initTheSystem initTheSystem;
+    
+    private final List<String> failTests = new ArrayList<>();
+    private final List<String> passTests = new ArrayList<>();
+
+    public EventManagementTest(UserService userService, EventService eventService, initTheSystem initTheSystem) {
+        this.userService = userService;
+        this.eventService = eventService;
+        this.initTheSystem = initTheSystem;
+    }
+
+    public String runAllTests() {
+        StringBuilder results = new StringBuilder();
+        results.append("Event Management Acceptance Tests:\n");
+
+        runTest("1", "Full Cycle: Create, Update, and Delete Event", this::fullEventLifecycleTest, results);
+        runTest("2", "Fail to Update Event That Does Not Exist", this::updateNonExistentEventTest, results);
+        runTest("3", "Fail to Delete Event Without Permissions", this::deleteEventWithoutPermissionsTest, results);
+
+        return results.toString();
+    }
+
+    private void runTest(String testId, String description, java.util.function.Supplier<Boolean> testLogic, StringBuilder results) {
+        initTheSystem.init(); 
+        boolean result;
+        try {
+            result = testLogic.get();
+        } catch (Exception e) {
+            result = false;
+        }
+
+        results.append("Test ").append(testId).append(" - ").append(description).append(": ").append(result ? "PASS" : "FAIL").append("\n");
+        if (result) passTests.add(testId); else failTests.add(testId);
+    }
+
+    public boolean fullEventLifecycleTest() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+
+        String eventId = eventService.createEvent("Shlomo Artzi Concert", "2026-08-15", "Caesarea", token);
+        if (eventId == null || eventId.isEmpty() || eventId.equals("failed")) {
+            return false;
+        }
+
+        String updateResult = eventService.updateEventDate(eventId, "2026-08-16", token);
+        if (!updateResult.equals("success")) {
+            return false;
+        }
+
+        String deleteResult = eventService.deleteEvent(eventId, token);
+        if (!deleteResult.equals("success")) {
+            return false;
+        }
+
+        String getEventResult = eventService.getEventInfo(eventId);
+        return getEventResult.equals("failed_not_found");
+    }
+
+    public boolean updateNonExistentEventTest() {
+        userService.register("user1", "pass");
+        String token = userService.login("user1", "pass");
+        
+        String result = eventService.updateEventDate("fake-id-999", "2026-10-10", token);
+        return result.equals("failed");
+    }
+
+    public boolean deleteEventWithoutPermissionsTest() {
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken);
+
+        userService.register("hacker", "hackerPass");
+        String hackerToken = userService.login("hacker", "hackerPass");
+        
+        String deleteResult = eventService.deleteEvent(eventId, hackerToken);
+        return deleteResult.equals("failed_no_permission");
+    }
+}

--- a/src/main/java/Appliction/EventService.java
+++ b/src/main/java/Appliction/EventService.java
@@ -1,0 +1,71 @@
+package Appliction;
+
+//TEST PURPOSE ONLY - NOT FINAL IMPLEMENTATION!
+public class EventService {
+
+    private String lastCreatorToken = "";
+    private boolean isDeleted = false;
+
+    public String createEvent(String name, String date, String location, String token) {
+        if (token == null || token.isEmpty() || name == null || name.isEmpty() || date == null || date.isEmpty() || location == null || location.isEmpty()) {
+            return "failed";
+        }
+        if (date.equals("2020-01-01") || date.equals("invalid-date")) {
+            return "failed";
+        }
+        this.lastCreatorToken = token;
+        this.isDeleted = false;
+        return "event-12345";
+    }
+
+    public String updateEventDate(String eventId, String newDate, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        return "success";
+    }
+
+    public String updateEventName(String eventId, String newName, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        return "success";
+    }
+
+    public String updateEventLocation(String eventId, String newLocation, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        return "success";
+    }
+
+    public String deleteEvent(String eventId, String token) {
+        if (eventId.equals("fake-id-999")) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        if (this.isDeleted) {
+            return "failed_already_deleted";
+        }
+        this.isDeleted = true;
+        return "success";
+    }
+
+    public String getEventInfo(String eventId) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed_not_found";
+        }
+        return "event_info_string";
+    }
+}


### PR DESCRIPTION
הוספתי סט של בדיקות קבלה עבור ניהול אירועים במערכת. 
הבדיקות מכסות את כל מחזור החיים של אירוע כולל:
- יצירת אירוע
- עדכון פרטי אירוע
-מחיקת אירוע וניסיון מחיקה כפול
- בדיקות אבטחה והרשאות  (משתמש ללא הרשאות לא יכול לעדכן או למחוק אירוע של מישהו אחר).
- עדכון ה-`AllTestRun` כך שיריץ גם את הטסטים החדשים.


מחלקת ה-`EventService` שהוספתי תחת `Appliction` היא מחלקה זמנית בלבד. 
יצרתי אותה אך ורק כדי לקבוע את החוזה  של הפונקציות, וכדי שהטסטים יתקמפלו ויעברו בהצלחה. 
אין שם לוגיקה אמיתית! מי שאחראי על מימוש אירועים במערכת שיחליף את הלוגיקה המזויפת בתוך הפונקציות הקיימות בלוגיקה האמיתית של המערכת.

 איך לבדוק שעובד:
להריץ את `AllTestRun` ולוודא שתחת הפלט של "Event Management Acceptance Tests" מופיעים 17 טסטים שמחזירים true.