### PR TITLE
Refactor architecture response object

### DIFF
--- a/src/main/java/AcceptanceTest/users/AllTestRun.java
+++ b/src/main/java/AcceptanceTest/users/AllTestRun.java
@@ -3,6 +3,7 @@ package AcceptanceTest.users;
 
 import AcceptanceTest.users.CompanyManagementTest.CompanyManagementTest;
 import AcceptanceTest.users.EventManagementTest.EventManagementTest;
+import AcceptanceTest.users.EventManagementTest.ViewEventInfoTest;
 import AcceptanceTest.users.visitorTests.UserActionInfo;
 import Appliction.CompanyService;
 import Appliction.EventService;
@@ -18,6 +19,7 @@ public class AllTestRun {
     private UserActionInfo visitorActionTest;
     private CompanyManagementTest companyManagementTest;
     private EventManagementTest eventManagementTest;
+    private ViewEventInfoTest viewEventInfoTest;
 
 //    private AdminTests adminTests;
     public AllTestRun() {
@@ -36,7 +38,7 @@ public class AllTestRun {
         visitorActionTest = new UserActionInfo(userService,initTheSystem);
         companyManagementTest=new CompanyManagementTest(companyService,userService,initTheSystem);
         eventManagementTest = new EventManagementTest(userService, eventService, initTheSystem);
-        
+        viewEventInfoTest = new ViewEventInfoTest(userService, eventService, initTheSystem);
     }
     public void runAllTests() {
         System.out.println("Visitor action test ");
@@ -45,6 +47,7 @@ public class AllTestRun {
         String CompanyActionTestResults=companyManagementTest.whichTestPass();
         String CompanyActionTestResultsFailed=companyManagementTest.SeeFailTest();
         String eventTestResults = eventManagementTest.runAllTests();
+        String viewEventTestResults = viewEventInfoTest.runAllTests();
 
         System.out.println(visitorActionTestResults);
         System.out.println(visitorActionTestResultsFailed);
@@ -53,6 +56,8 @@ public class AllTestRun {
         System.out.println(CompanyActionTestResultsFailed);
         System.out.println("-------------------------------------------------");
         System.out.println(eventTestResults);
+        System.out.println("-------------------------------------------------");
+        System.out.println(viewEventTestResults);
         
 
     }

--- a/src/main/java/AcceptanceTest/users/AllTestRun.java
+++ b/src/main/java/AcceptanceTest/users/AllTestRun.java
@@ -4,10 +4,12 @@ package AcceptanceTest.users;
 import AcceptanceTest.users.CompanyManagementTest.CompanyManagementTest;
 import AcceptanceTest.users.EventManagementTest.EventManagementTest;
 import AcceptanceTest.users.EventManagementTest.ViewEventInfoTest;
+import AcceptanceTest.users.OrderManagementTest.ReserveOrderTest;
 import AcceptanceTest.users.visitorTests.UserActionInfo;
 import Appliction.CompanyService;
 import Appliction.EventService;
 import Appliction.IPasswordEncoder;
+import Appliction.OrderService;
 import Appliction.UserService;
 import Domain.Company.iCompanyRepository;
 import Domain.OwnerManagerTree.iTreeOfRoleRepository;
@@ -20,6 +22,7 @@ public class AllTestRun {
     private CompanyManagementTest companyManagementTest;
     private EventManagementTest eventManagementTest;
     private ViewEventInfoTest viewEventInfoTest;
+    private ReserveOrderTest reserveOrderTest;
 
 //    private AdminTests adminTests;
     public AllTestRun() {
@@ -34,11 +37,13 @@ public class AllTestRun {
         UserService userService=new UserService(iPasswordEncoder,iUserRepository,tokenService);
         CompanyService companyService=new CompanyService(iCompanyRepository,iUserRepository,iTreeOfRoleRepository,tokenService);
         EventService eventService = new EventService();
+        OrderService orderService = new OrderService();
 
         visitorActionTest = new UserActionInfo(userService,initTheSystem);
         companyManagementTest=new CompanyManagementTest(companyService,userService,initTheSystem);
         eventManagementTest = new EventManagementTest(userService, eventService, initTheSystem);
         viewEventInfoTest = new ViewEventInfoTest(userService, eventService, initTheSystem);
+        reserveOrderTest = new ReserveOrderTest(userService, eventService, orderService, initTheSystem);
     }
     public void runAllTests() {
         System.out.println("Visitor action test ");
@@ -48,6 +53,7 @@ public class AllTestRun {
         String CompanyActionTestResultsFailed=companyManagementTest.SeeFailTest();
         String eventTestResults = eventManagementTest.runAllTests();
         String viewEventTestResults = viewEventInfoTest.runAllTests();
+        String reserveOrderTestResults = reserveOrderTest.runAllTests();
 
         System.out.println(visitorActionTestResults);
         System.out.println(visitorActionTestResultsFailed);
@@ -58,6 +64,8 @@ public class AllTestRun {
         System.out.println(eventTestResults);
         System.out.println("-------------------------------------------------");
         System.out.println(viewEventTestResults);
+        System.out.println("-------------------------------------------------");
+        System.out.println(reserveOrderTestResults);
         
 
     }

--- a/src/main/java/AcceptanceTest/users/AllTestRun.java
+++ b/src/main/java/AcceptanceTest/users/AllTestRun.java
@@ -2,8 +2,10 @@ package AcceptanceTest.users;
 
 
 import AcceptanceTest.users.CompanyManagementTest.CompanyManagementTest;
+import AcceptanceTest.users.EventManagementTest.EventManagementTest;
 import AcceptanceTest.users.visitorTests.UserActionInfo;
 import Appliction.CompanyService;
+import Appliction.EventService;
 import Appliction.IPasswordEncoder;
 import Appliction.UserService;
 import Domain.Company.iCompanyRepository;
@@ -15,7 +17,7 @@ import Infastructure.*;
 public class AllTestRun {
     private UserActionInfo visitorActionTest;
     private CompanyManagementTest companyManagementTest;
-
+    private EventManagementTest eventManagementTest;
 
 //    private AdminTests adminTests;
     public AllTestRun() {
@@ -29,11 +31,12 @@ public class AllTestRun {
 
         UserService userService=new UserService(iPasswordEncoder,iUserRepository,tokenService);
         CompanyService companyService=new CompanyService(iCompanyRepository,iUserRepository,iTreeOfRoleRepository,tokenService);
-
+        EventService eventService = new EventService();
 
         visitorActionTest = new UserActionInfo(userService,initTheSystem);
         companyManagementTest=new CompanyManagementTest(companyService,userService,initTheSystem);
-
+        eventManagementTest = new EventManagementTest(userService, eventService, initTheSystem);
+        
     }
     public void runAllTests() {
         System.out.println("Visitor action test ");
@@ -41,13 +44,16 @@ public class AllTestRun {
         String visitorActionTestResultsFailed=visitorActionTest.SeeFailTest();
         String CompanyActionTestResults=companyManagementTest.whichTestPass();
         String CompanyActionTestResultsFailed=companyManagementTest.SeeFailTest();
-
+        String eventTestResults = eventManagementTest.runAllTests();
 
         System.out.println(visitorActionTestResults);
         System.out.println(visitorActionTestResultsFailed);
+        System.out.println("-------------------------------------------------");
         System.out.println(CompanyActionTestResults);
         System.out.println(CompanyActionTestResultsFailed);
-
+        System.out.println("-------------------------------------------------");
+        System.out.println(eventTestResults);
+        
 
     }
 }

--- a/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
+++ b/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
@@ -3,6 +3,7 @@ package AcceptanceTest.users.EventManagementTest;
 import AcceptanceTest.users.initTheSystem;
 import Appliction.UserService;
 import Appliction.EventService;
+import Appliction.Response;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -53,23 +54,12 @@ public class EventManagementTest {
 
         testMap.forEach((id, testLogic) -> {
             initTheSystem.init(); 
-            
             boolean result;
-            try {
-                result = testLogic.get();
-            } catch (Exception e) {
-                result = false;
-            }
-
+            try { result = testLogic.get(); } 
+            catch (Exception e) { result = false; }
             stringBuilder.append("the result of test ").append(id).append(": ").append(result).append("\n");
-
-            if (result) {
-                passTests.add(id);
-            } else {
-                failTests.add(id);
-            }
+            if (result) passTests.add(id); else failTests.add(id);
         });
-
         return stringBuilder.toString();
     }
 
@@ -77,149 +67,148 @@ public class EventManagementTest {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
 
-        String eventId = eventService.createEvent("Shlomo Artzi Concert", "2026-08-15", "Caesarea", token);
-        if (eventId == null || eventId.isEmpty() || eventId.equals("failed")) return false;
+        Response<String> createRes = eventService.createEvent("Shlomo Artzi Concert", "2026-08-15", "Caesarea", token);
+        if (!createRes.isSuccess() || createRes.getData() == null) return false;
 
-        String updateResult = eventService.updateEventDate(eventId, "2026-08-16", token);
-        if (!updateResult.equals("success")) return false;
+        String eventId = createRes.getData();
+        Response<Void> updateRes = eventService.updateEventDate(eventId, "2026-08-16", token);
+        if (!updateRes.isSuccess()) return false;
 
-        String deleteResult = eventService.deleteEvent(eventId, token);
-        if (!deleteResult.equals("success")) return false;
+        Response<Void> deleteRes = eventService.deleteEvent(eventId, token);
+        if (!deleteRes.isSuccess()) return false;
 
-        String getEventResult = eventService.getEventInfo(eventId);
-        return getEventResult.equals("failed_not_found");
+        Response<String> getRes = eventService.getEventInfo(eventId);
+        return !getRes.isSuccess();
     }
 
     public boolean createEventFailedNoToken() {
-        String result = eventService.createEvent("Coldplay Live", "2026-09-01", "Park Hayarkon", "");
-        return result.equals("failed");
+        Response<String> result = eventService.createEvent("Coldplay Live", "2026-09-01", "Park Hayarkon", "");
+        return !result.isSuccess();
     }
 
     public boolean createEventFailedMissingFields() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String result = eventService.createEvent("", "", "Tel Aviv", token);
-        return result.equals("failed");
+        Response<String> result = eventService.createEvent("", "", "Tel Aviv", token);
+        return !result.isSuccess();
     }
 
     public boolean updateEventSuccess() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String eventId = eventService.createEvent("Jazz Festival", "2026-05-05", "Jerusalem", token);
+        String eventId = eventService.createEvent("Jazz Festival", "2026-05-05", "Jerusalem", token).getData();
         
-        String result = eventService.updateEventDate(eventId, "2026-05-06", token);
-        return result.equals("success");
+        Response<Void> result = eventService.updateEventDate(eventId, "2026-05-06", token);
+        return result.isSuccess();
     }
 
     public boolean updateNonExistentEventTest() {
         userService.register("user1", "pass");
         String token = userService.login("user1", "pass");
-        
-        String result = eventService.updateEventDate("fake-id-999", "2026-10-10", token);
-        return result.equals("failed");
+        Response<Void> result = eventService.updateEventDate("fake-id-999", "2026-10-10", token);
+        return !result.isSuccess();
     }
 
     public boolean updateEventFailedNoPermission() {
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken);
+        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken).getData();
 
         userService.register("hacker", "hackerPass");
         String hackerToken = userService.login("hacker", "hackerPass");
         
-        String updateResult = eventService.updateEventDate(eventId, "2026-01-02", hackerToken);
-        return updateResult.equals("failed_no_permission");
+        Response<Void> result = eventService.updateEventDate(eventId, "2026-01-02", hackerToken);
+        return !result.isSuccess();
     }
 
     public boolean deleteEventSuccess() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String eventId = eventService.createEvent("Tech Conference", "2026-11-11", "Expo TLV", token);
+        String eventId = eventService.createEvent("Tech Conference", "2026-11-11", "Expo TLV", token).getData();
         
-        String result = eventService.deleteEvent(eventId, token);
-        return result.equals("success");
+        Response<Void> result = eventService.deleteEvent(eventId, token);
+        return result.isSuccess();
     }
 
     public boolean deleteEventWithoutPermissionsTest() {
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken);
+        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken).getData();
 
         userService.register("hacker", "hackerPass");
         String hackerToken = userService.login("hacker", "hackerPass");
         
-        String deleteResult = eventService.deleteEvent(eventId, hackerToken);
-        return deleteResult.equals("failed_no_permission");
+        Response<Void> result = eventService.deleteEvent(eventId, hackerToken);
+        return !result.isSuccess();
     }
 
     public boolean deleteNonExistentEventTest() {
         userService.register("user1", "pass");
         String token = userService.login("user1", "pass");
-        
-        String result = eventService.deleteEvent("fake-id-999", token);
-        return result.equals("failed");
+        Response<Void> result = eventService.deleteEvent("fake-id-999", token);
+        return !result.isSuccess();
     }
 
     public boolean createEventFailedPastDate() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String result = eventService.createEvent("Old Event", "2020-01-01", "Haifa", token);
-        return result.equals("failed");
+        Response<String> result = eventService.createEvent("Old Event", "2020-01-01", "Haifa", token);
+        return !result.isSuccess();
     }
 
     public boolean createEventFailedInvalidDateFormat() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String result = eventService.createEvent("Bad Date Event", "invalid-date", "Eilat", token);
-        return result.equals("failed");
+        Response<String> result = eventService.createEvent("Bad Date Event", "invalid-date", "Eilat", token);
+        return !result.isSuccess();
     }
 
     public boolean updateEventNameSuccess() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String eventId = eventService.createEvent("Initial Name", "2026-08-15", "Caesarea", token);
-        String result = eventService.updateEventName(eventId, "Updated Name", token);
-        return result.equals("success");
+        String eventId = eventService.createEvent("Initial Name", "2026-08-15", "Caesarea", token).getData();
+        Response<Void> result = eventService.updateEventName(eventId, "Updated Name", token);
+        return result.isSuccess();
     }
 
     public boolean updateEventNameFailedNoPermission() {
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("My Event", "2026-01-01", "Tel Aviv", adminToken);
+        String eventId = eventService.createEvent("My Event", "2026-01-01", "Tel Aviv", adminToken).getData();
 
         userService.register("user2", "pass2");
         String userToken = userService.login("user2", "pass2");
-        String result = eventService.updateEventName(eventId, "Hacked Name", userToken);
-        return result.equals("failed_no_permission");
+        Response<Void> result = eventService.updateEventName(eventId, "Hacked Name", userToken);
+        return !result.isSuccess();
     }
 
     public boolean updateEventLocationSuccess() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String eventId = eventService.createEvent("Moving Event", "2026-08-15", "Haifa", token);
-        String result = eventService.updateEventLocation(eventId, "Tel Aviv", token);
-        return result.equals("success");
+        String eventId = eventService.createEvent("Moving Event", "2026-08-15", "Haifa", token).getData();
+        Response<Void> result = eventService.updateEventLocation(eventId, "Tel Aviv", token);
+        return result.isSuccess();
     }
 
     public boolean deleteEventTwiceFailed() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String eventId = eventService.createEvent("Double Delete", "2026-11-11", "Expo TLV", token);
+        String eventId = eventService.createEvent("Double Delete", "2026-11-11", "Expo TLV", token).getData();
         eventService.deleteEvent(eventId, token);
-        String result = eventService.deleteEvent(eventId, token);
-        return result.equals("failed_already_deleted");
+        Response<Void> result = eventService.deleteEvent(eventId, token);
+        return !result.isSuccess();
     }
 
     public boolean getEventInfoSuccess() {
         userService.register("adminUser", "password123");
         String token = userService.login("adminUser", "password123");
-        String eventId = eventService.createEvent("Info Event", "2026-12-12", "Eilat", token);
-        String result = eventService.getEventInfo(eventId);
-        return !result.equals("failed_not_found") && !result.isEmpty();
+        String eventId = eventService.createEvent("Info Event", "2026-12-12", "Eilat", token).getData();
+        Response<String> result = eventService.getEventInfo(eventId);
+        return result.isSuccess() && result.getData() != null;
     }
 
     public boolean getEventInfoFailedNotExist() {
-        String result = eventService.getEventInfo("fake-id-999");
-        return result.equals("failed_not_found");
+        Response<String> result = eventService.getEventInfo("fake-id-999");
+        return !result.isSuccess();
     }
 }

--- a/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
+++ b/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
@@ -5,7 +5,10 @@ import Appliction.UserService;
 import Appliction.EventService;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 public class EventManagementTest {
     
@@ -15,35 +18,59 @@ public class EventManagementTest {
     
     private final List<String> failTests = new ArrayList<>();
     private final List<String> passTests = new ArrayList<>();
+    private final Map<String, Supplier<Boolean>> testMap = new LinkedHashMap<>();
 
     public EventManagementTest(UserService userService, EventService eventService, initTheSystem initTheSystem) {
         this.userService = userService;
         this.eventService = eventService;
         this.initTheSystem = initTheSystem;
+        initTestMap();
+    }
+
+    private void initTestMap() {
+        testMap.put("1", this::fullEventLifecycleTest);
+        testMap.put("2", this::createEventFailedNoToken);
+        testMap.put("3", this::createEventFailedMissingFields);
+        testMap.put("4", this::updateEventSuccess);
+        testMap.put("5", this::updateNonExistentEventTest);
+        testMap.put("6", this::updateEventFailedNoPermission);
+        testMap.put("7", this::deleteEventSuccess);
+        testMap.put("8", this::deleteEventWithoutPermissionsTest);
+        testMap.put("9", this::deleteNonExistentEventTest);
+        testMap.put("10", this::createEventFailedPastDate);
+        testMap.put("11", this::createEventFailedInvalidDateFormat);
+        testMap.put("12", this::updateEventNameSuccess);
+        testMap.put("13", this::updateEventNameFailedNoPermission);
+        testMap.put("14", this::updateEventLocationSuccess);
+        testMap.put("15", this::deleteEventTwiceFailed);
+        testMap.put("16", this::getEventInfoSuccess);
+        testMap.put("17", this::getEventInfoFailedNotExist);
     }
 
     public String runAllTests() {
-        StringBuilder results = new StringBuilder();
-        results.append("Event Management Acceptance Tests:\n");
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("Event Management Acceptance Tests:\n");
 
-        runTest("1", "Full Cycle: Create, Update, and Delete Event", this::fullEventLifecycleTest, results);
-        runTest("2", "Fail to Update Event That Does Not Exist", this::updateNonExistentEventTest, results);
-        runTest("3", "Fail to Delete Event Without Permissions", this::deleteEventWithoutPermissionsTest, results);
+        testMap.forEach((id, testLogic) -> {
+            initTheSystem.init(); 
+            
+            boolean result;
+            try {
+                result = testLogic.get();
+            } catch (Exception e) {
+                result = false;
+            }
 
-        return results.toString();
-    }
+            stringBuilder.append("the result of test ").append(id).append(": ").append(result).append("\n");
 
-    private void runTest(String testId, String description, java.util.function.Supplier<Boolean> testLogic, StringBuilder results) {
-        initTheSystem.init(); 
-        boolean result;
-        try {
-            result = testLogic.get();
-        } catch (Exception e) {
-            result = false;
-        }
+            if (result) {
+                passTests.add(id);
+            } else {
+                failTests.add(id);
+            }
+        });
 
-        results.append("Test ").append(testId).append(" - ").append(description).append(": ").append(result ? "PASS" : "FAIL").append("\n");
-        if (result) passTests.add(testId); else failTests.add(testId);
+        return stringBuilder.toString();
     }
 
     public boolean fullEventLifecycleTest() {
@@ -51,22 +78,37 @@ public class EventManagementTest {
         String token = userService.login("adminUser", "password123");
 
         String eventId = eventService.createEvent("Shlomo Artzi Concert", "2026-08-15", "Caesarea", token);
-        if (eventId == null || eventId.isEmpty() || eventId.equals("failed")) {
-            return false;
-        }
+        if (eventId == null || eventId.isEmpty() || eventId.equals("failed")) return false;
 
         String updateResult = eventService.updateEventDate(eventId, "2026-08-16", token);
-        if (!updateResult.equals("success")) {
-            return false;
-        }
+        if (!updateResult.equals("success")) return false;
 
         String deleteResult = eventService.deleteEvent(eventId, token);
-        if (!deleteResult.equals("success")) {
-            return false;
-        }
+        if (!deleteResult.equals("success")) return false;
 
         String getEventResult = eventService.getEventInfo(eventId);
         return getEventResult.equals("failed_not_found");
+    }
+
+    public boolean createEventFailedNoToken() {
+        String result = eventService.createEvent("Coldplay Live", "2026-09-01", "Park Hayarkon", "");
+        return result.equals("failed");
+    }
+
+    public boolean createEventFailedMissingFields() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String result = eventService.createEvent("", "", "Tel Aviv", token);
+        return result.equals("failed");
+    }
+
+    public boolean updateEventSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Jazz Festival", "2026-05-05", "Jerusalem", token);
+        
+        String result = eventService.updateEventDate(eventId, "2026-05-06", token);
+        return result.equals("success");
     }
 
     public boolean updateNonExistentEventTest() {
@@ -75,6 +117,27 @@ public class EventManagementTest {
         
         String result = eventService.updateEventDate("fake-id-999", "2026-10-10", token);
         return result.equals("failed");
+    }
+
+    public boolean updateEventFailedNoPermission() {
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken);
+
+        userService.register("hacker", "hackerPass");
+        String hackerToken = userService.login("hacker", "hackerPass");
+        
+        String updateResult = eventService.updateEventDate(eventId, "2026-01-02", hackerToken);
+        return updateResult.equals("failed_no_permission");
+    }
+
+    public boolean deleteEventSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Tech Conference", "2026-11-11", "Expo TLV", token);
+        
+        String result = eventService.deleteEvent(eventId, token);
+        return result.equals("success");
     }
 
     public boolean deleteEventWithoutPermissionsTest() {
@@ -87,5 +150,76 @@ public class EventManagementTest {
         
         String deleteResult = eventService.deleteEvent(eventId, hackerToken);
         return deleteResult.equals("failed_no_permission");
+    }
+
+    public boolean deleteNonExistentEventTest() {
+        userService.register("user1", "pass");
+        String token = userService.login("user1", "pass");
+        
+        String result = eventService.deleteEvent("fake-id-999", token);
+        return result.equals("failed");
+    }
+
+    public boolean createEventFailedPastDate() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String result = eventService.createEvent("Old Event", "2020-01-01", "Haifa", token);
+        return result.equals("failed");
+    }
+
+    public boolean createEventFailedInvalidDateFormat() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String result = eventService.createEvent("Bad Date Event", "invalid-date", "Eilat", token);
+        return result.equals("failed");
+    }
+
+    public boolean updateEventNameSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Initial Name", "2026-08-15", "Caesarea", token);
+        String result = eventService.updateEventName(eventId, "Updated Name", token);
+        return result.equals("success");
+    }
+
+    public boolean updateEventNameFailedNoPermission() {
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("My Event", "2026-01-01", "Tel Aviv", adminToken);
+
+        userService.register("user2", "pass2");
+        String userToken = userService.login("user2", "pass2");
+        String result = eventService.updateEventName(eventId, "Hacked Name", userToken);
+        return result.equals("failed_no_permission");
+    }
+
+    public boolean updateEventLocationSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Moving Event", "2026-08-15", "Haifa", token);
+        String result = eventService.updateEventLocation(eventId, "Tel Aviv", token);
+        return result.equals("success");
+    }
+
+    public boolean deleteEventTwiceFailed() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Double Delete", "2026-11-11", "Expo TLV", token);
+        eventService.deleteEvent(eventId, token);
+        String result = eventService.deleteEvent(eventId, token);
+        return result.equals("failed_already_deleted");
+    }
+
+    public boolean getEventInfoSuccess() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+        String eventId = eventService.createEvent("Info Event", "2026-12-12", "Eilat", token);
+        String result = eventService.getEventInfo(eventId);
+        return !result.equals("failed_not_found") && !result.isEmpty();
+    }
+
+    public boolean getEventInfoFailedNotExist() {
+        String result = eventService.getEventInfo("fake-id-999");
+        return result.equals("failed_not_found");
     }
 }

--- a/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
+++ b/src/main/java/AcceptanceTest/users/EventManagementTest/EventManagementTest.java
@@ -1,0 +1,91 @@
+package AcceptanceTest.users.EventManagementTest;
+
+import AcceptanceTest.users.initTheSystem;
+import Appliction.UserService;
+import Appliction.EventService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventManagementTest {
+    
+    private UserService userService;
+    private EventService eventService; 
+    private initTheSystem initTheSystem;
+    
+    private final List<String> failTests = new ArrayList<>();
+    private final List<String> passTests = new ArrayList<>();
+
+    public EventManagementTest(UserService userService, EventService eventService, initTheSystem initTheSystem) {
+        this.userService = userService;
+        this.eventService = eventService;
+        this.initTheSystem = initTheSystem;
+    }
+
+    public String runAllTests() {
+        StringBuilder results = new StringBuilder();
+        results.append("Event Management Acceptance Tests:\n");
+
+        runTest("1", "Full Cycle: Create, Update, and Delete Event", this::fullEventLifecycleTest, results);
+        runTest("2", "Fail to Update Event That Does Not Exist", this::updateNonExistentEventTest, results);
+        runTest("3", "Fail to Delete Event Without Permissions", this::deleteEventWithoutPermissionsTest, results);
+
+        return results.toString();
+    }
+
+    private void runTest(String testId, String description, java.util.function.Supplier<Boolean> testLogic, StringBuilder results) {
+        initTheSystem.init(); 
+        boolean result;
+        try {
+            result = testLogic.get();
+        } catch (Exception e) {
+            result = false;
+        }
+
+        results.append("Test ").append(testId).append(" - ").append(description).append(": ").append(result ? "PASS" : "FAIL").append("\n");
+        if (result) passTests.add(testId); else failTests.add(testId);
+    }
+
+    public boolean fullEventLifecycleTest() {
+        userService.register("adminUser", "password123");
+        String token = userService.login("adminUser", "password123");
+
+        String eventId = eventService.createEvent("Shlomo Artzi Concert", "2026-08-15", "Caesarea", token);
+        if (eventId == null || eventId.isEmpty() || eventId.equals("failed")) {
+            return false;
+        }
+
+        String updateResult = eventService.updateEventDate(eventId, "2026-08-16", token);
+        if (!updateResult.equals("success")) {
+            return false;
+        }
+
+        String deleteResult = eventService.deleteEvent(eventId, token);
+        if (!deleteResult.equals("success")) {
+            return false;
+        }
+
+        String getEventResult = eventService.getEventInfo(eventId);
+        return getEventResult.equals("failed_not_found");
+    }
+
+    public boolean updateNonExistentEventTest() {
+        userService.register("user1", "pass");
+        String token = userService.login("user1", "pass");
+        
+        String result = eventService.updateEventDate("fake-id-999", "2026-10-10", token);
+        return result.equals("failed");
+    }
+
+    public boolean deleteEventWithoutPermissionsTest() {
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Private Party", "2026-01-01", "Tel Aviv", adminToken);
+
+        userService.register("hacker", "hackerPass");
+        String hackerToken = userService.login("hacker", "hackerPass");
+        
+        String deleteResult = eventService.deleteEvent(eventId, hackerToken);
+        return deleteResult.equals("failed_no_permission");
+    }
+}

--- a/src/main/java/AcceptanceTest/users/EventManagementTest/ViewEventInfoTest.java
+++ b/src/main/java/AcceptanceTest/users/EventManagementTest/ViewEventInfoTest.java
@@ -2,6 +2,7 @@ package AcceptanceTest.users.EventManagementTest;
 import AcceptanceTest.users.initTheSystem;
 import Appliction.UserService;
 import Appliction.EventService;
+import Appliction.Response;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -50,18 +51,11 @@ public class ViewEventInfoTest {
         testMap.forEach((id, testLogic) -> {
             initTheSystem.init();
             boolean result;
-            try {
-                result = testLogic.get();
-            } catch (Exception e) {
-                result = false;
-            }
-
+            try { result = testLogic.get(); } 
+            catch (Exception e) { result = false; }
             stringBuilder.append("the result of test ").append(id).append(": ").append(result).append("\n");
-
-            if (result) passTests.add(id);
-            else failTests.add(id);
+            if (result) passTests.add(id); else failTests.add(id);
         });
-
         return stringBuilder.toString();
     }
 
@@ -70,13 +64,13 @@ public class ViewEventInfoTest {
         String token = userService.login("adminUser", "password");
         eventService.createEvent("Concert", "2026-10-10", "TLV", token);
         
-        String result = eventService.getAllEvents();
-        return !result.equals("failed_empty") && result.contains("Concert");
+        Response<String> result = eventService.getAllEvents();
+        return result.isSuccess() && result.getData().contains("Concert");
     }
 
     public boolean viewAllEventsEmptySystem() {
-        String result = eventService.getAllEvents();
-        return result.equals("failed_empty");
+        Response<String> result = eventService.getAllEvents();
+        return !result.isSuccess();
     }
 
     public boolean searchEventByDateSuccess() {
@@ -84,13 +78,13 @@ public class ViewEventInfoTest {
         String token = userService.login("adminUser", "password");
         eventService.createEvent("Party", "2026-12-31", "Haifa", token);
         
-        String result = eventService.searchEventsByDate("2026-12-31");
-        return result.contains("Party");
+        Response<String> result = eventService.searchEventsByDate("2026-12-31");
+        return result.isSuccess() && result.getData().contains("Party");
     }
 
     public boolean searchEventByDateNotFound() {
-        String result = eventService.searchEventsByDate("2030-01-01");
-        return result.equals("failed_not_found");
+        Response<String> result = eventService.searchEventsByDate("2030-01-01");
+        return !result.isSuccess();
     }
 
     public boolean searchEventByCategorySuccess() {
@@ -98,27 +92,27 @@ public class ViewEventInfoTest {
         String token = userService.login("adminUser", "password");
         eventService.createEvent("Standup", "2026-08-08", "Eilat", token);
         
-        String result = eventService.searchEventsByCategory("Comedy");
-        return result.contains("Standup");
+        Response<String> result = eventService.searchEventsByCategory("Comedy");
+        return result.isSuccess() && result.getData().contains("Standup");
     }
 
     public boolean searchEventByCategoryNotFound() {
-        String result = eventService.searchEventsByCategory("Sports");
-        return result.equals("failed_not_found");
+        Response<String> result = eventService.searchEventsByCategory("Sports");
+        return !result.isSuccess();
     }
 
     public boolean checkAvailableTicketsSuccess() {
         userService.register("adminUser", "password");
         String token = userService.login("adminUser", "password");
-        String eventId = eventService.createEvent("Movie", "2026-07-07", "Cinema", token);
+        String eventId = eventService.createEvent("Movie", "2026-07-07", "Cinema", token).getData();
         
-        int tickets = eventService.getAvailableTickets(eventId);
-        return tickets > 0;
+        Response<Integer> result = eventService.getAvailableTickets(eventId);
+        return result.isSuccess() && result.getData() > 0;
     }
 
     public boolean checkAvailableTicketsFailedEventNotFound() {
-        int tickets = eventService.getAvailableTickets("fake-id-999");
-        return tickets == -1;
+        Response<Integer> result = eventService.getAvailableTickets("fake-id-999");
+        return !result.isSuccess();
     }
 
     public boolean searchEventByNameSuccess() {
@@ -126,13 +120,13 @@ public class ViewEventInfoTest {
         String token = userService.login("adminUser", "password");
         eventService.createEvent("Coldplay", "2026-09-09", "Park Hayarkon", token);
         
-        String result = eventService.searchEventsByName("Coldplay");
-        return result.contains("Coldplay");
+        Response<String> result = eventService.searchEventsByName("Coldplay");
+        return result.isSuccess() && result.getData().contains("Coldplay");
     }
 
     public boolean searchEventByNameNotFound() {
-        String result = eventService.searchEventsByName("UnknownBand");
-        return result.equals("failed_not_found");
+        Response<String> result = eventService.searchEventsByName("UnknownBand");
+        return !result.isSuccess();
     }
 
     public boolean searchEventByLocationSuccess() {
@@ -140,22 +134,18 @@ public class ViewEventInfoTest {
         String token = userService.login("adminUser", "password");
         eventService.createEvent("Tech Meetup", "2026-05-05", "Tel Aviv", token);
         
-        String result = eventService.searchEventsByLocation("Tel Aviv");
-        return result.contains("Tech Meetup");
+        Response<String> result = eventService.searchEventsByLocation("Tel Aviv");
+        return result.isSuccess() && result.getData().contains("Tech Meetup");
     }
 
     public boolean searchEventByLocationNotFound() {
-        String result = eventService.searchEventsByLocation("NowhereCity");
-        return result.equals("failed_not_found");
+        Response<String> result = eventService.searchEventsByLocation("NowhereCity");
+        return !result.isSuccess();
     }
 
     public boolean checkAvailableTicketsSoldOut() {
-        userService.register("adminUser", "password");
-        String token = userService.login("adminUser", "password");
-        String eventId = eventService.createEvent("Sold Out Show", "2026-01-01", "Barby", token);
-        
-        int tickets = eventService.getAvailableTickets("sold-out-id");
-        return tickets == 0;
+        Response<Integer> result = eventService.getAvailableTickets("sold-out-id");
+        return result.isSuccess() && result.getData() == 0;
     }
 
     public boolean viewAllEventsAsGuestSuccess() {
@@ -163,7 +153,7 @@ public class ViewEventInfoTest {
         String adminToken = userService.login("adminUser", "password");
         eventService.createEvent("Public Event", "2026-11-11", "Square", adminToken);
         
-        String result = eventService.getAllEvents();
-        return result.contains("Public Event");
+        Response<String> result = eventService.getAllEvents();
+        return result.isSuccess() && result.getData().contains("Public Event");
     }
 }

--- a/src/main/java/AcceptanceTest/users/EventManagementTest/ViewEventInfoTest.java
+++ b/src/main/java/AcceptanceTest/users/EventManagementTest/ViewEventInfoTest.java
@@ -1,0 +1,169 @@
+package AcceptanceTest.users.EventManagementTest;
+import AcceptanceTest.users.initTheSystem;
+import Appliction.UserService;
+import Appliction.EventService;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ViewEventInfoTest {
+
+    private UserService userService;
+    private EventService eventService;
+    private initTheSystem initTheSystem;
+
+    private final List<String> failTests = new ArrayList<>();
+    private final List<String> passTests = new ArrayList<>();
+    private final Map<String, Supplier<Boolean>> testMap = new LinkedHashMap<>();
+
+    public ViewEventInfoTest(UserService userService, EventService eventService, initTheSystem initTheSystem) {
+        this.userService = userService;
+        this.eventService = eventService;
+        this.initTheSystem = initTheSystem;
+        initTestMap();
+    }
+
+    private void initTestMap() {
+        testMap.put("1", this::viewAllEventsSuccess);
+        testMap.put("2", this::viewAllEventsEmptySystem);
+        testMap.put("3", this::searchEventByDateSuccess);
+        testMap.put("4", this::searchEventByDateNotFound);
+        testMap.put("5", this::searchEventByCategorySuccess);
+        testMap.put("6", this::searchEventByCategoryNotFound);
+        testMap.put("7", this::checkAvailableTicketsSuccess);
+        testMap.put("8", this::checkAvailableTicketsFailedEventNotFound);
+        testMap.put("9", this::searchEventByNameSuccess);
+        testMap.put("10", this::searchEventByNameNotFound);
+        testMap.put("11", this::searchEventByLocationSuccess);
+        testMap.put("12", this::searchEventByLocationNotFound);
+        testMap.put("13", this::checkAvailableTicketsSoldOut);
+        testMap.put("14", this::viewAllEventsAsGuestSuccess);
+    }
+
+    public String runAllTests() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("View Event Info Acceptance Tests:\n");
+
+        testMap.forEach((id, testLogic) -> {
+            initTheSystem.init();
+            boolean result;
+            try {
+                result = testLogic.get();
+            } catch (Exception e) {
+                result = false;
+            }
+
+            stringBuilder.append("the result of test ").append(id).append(": ").append(result).append("\n");
+
+            if (result) passTests.add(id);
+            else failTests.add(id);
+        });
+
+        return stringBuilder.toString();
+    }
+
+    public boolean viewAllEventsSuccess() {
+        userService.register("adminUser", "password");
+        String token = userService.login("adminUser", "password");
+        eventService.createEvent("Concert", "2026-10-10", "TLV", token);
+        
+        String result = eventService.getAllEvents();
+        return !result.equals("failed_empty") && result.contains("Concert");
+    }
+
+    public boolean viewAllEventsEmptySystem() {
+        String result = eventService.getAllEvents();
+        return result.equals("failed_empty");
+    }
+
+    public boolean searchEventByDateSuccess() {
+        userService.register("adminUser", "password");
+        String token = userService.login("adminUser", "password");
+        eventService.createEvent("Party", "2026-12-31", "Haifa", token);
+        
+        String result = eventService.searchEventsByDate("2026-12-31");
+        return result.contains("Party");
+    }
+
+    public boolean searchEventByDateNotFound() {
+        String result = eventService.searchEventsByDate("2030-01-01");
+        return result.equals("failed_not_found");
+    }
+
+    public boolean searchEventByCategorySuccess() {
+        userService.register("adminUser", "password");
+        String token = userService.login("adminUser", "password");
+        eventService.createEvent("Standup", "2026-08-08", "Eilat", token);
+        
+        String result = eventService.searchEventsByCategory("Comedy");
+        return result.contains("Standup");
+    }
+
+    public boolean searchEventByCategoryNotFound() {
+        String result = eventService.searchEventsByCategory("Sports");
+        return result.equals("failed_not_found");
+    }
+
+    public boolean checkAvailableTicketsSuccess() {
+        userService.register("adminUser", "password");
+        String token = userService.login("adminUser", "password");
+        String eventId = eventService.createEvent("Movie", "2026-07-07", "Cinema", token);
+        
+        int tickets = eventService.getAvailableTickets(eventId);
+        return tickets > 0;
+    }
+
+    public boolean checkAvailableTicketsFailedEventNotFound() {
+        int tickets = eventService.getAvailableTickets("fake-id-999");
+        return tickets == -1;
+    }
+
+    public boolean searchEventByNameSuccess() {
+        userService.register("adminUser", "password");
+        String token = userService.login("adminUser", "password");
+        eventService.createEvent("Coldplay", "2026-09-09", "Park Hayarkon", token);
+        
+        String result = eventService.searchEventsByName("Coldplay");
+        return result.contains("Coldplay");
+    }
+
+    public boolean searchEventByNameNotFound() {
+        String result = eventService.searchEventsByName("UnknownBand");
+        return result.equals("failed_not_found");
+    }
+
+    public boolean searchEventByLocationSuccess() {
+        userService.register("adminUser", "password");
+        String token = userService.login("adminUser", "password");
+        eventService.createEvent("Tech Meetup", "2026-05-05", "Tel Aviv", token);
+        
+        String result = eventService.searchEventsByLocation("Tel Aviv");
+        return result.contains("Tech Meetup");
+    }
+
+    public boolean searchEventByLocationNotFound() {
+        String result = eventService.searchEventsByLocation("NowhereCity");
+        return result.equals("failed_not_found");
+    }
+
+    public boolean checkAvailableTicketsSoldOut() {
+        userService.register("adminUser", "password");
+        String token = userService.login("adminUser", "password");
+        String eventId = eventService.createEvent("Sold Out Show", "2026-01-01", "Barby", token);
+        
+        int tickets = eventService.getAvailableTickets("sold-out-id");
+        return tickets == 0;
+    }
+
+    public boolean viewAllEventsAsGuestSuccess() {
+        userService.register("adminUser", "password");
+        String adminToken = userService.login("adminUser", "password");
+        eventService.createEvent("Public Event", "2026-11-11", "Square", adminToken);
+        
+        String result = eventService.getAllEvents();
+        return result.contains("Public Event");
+    }
+}

--- a/src/main/java/AcceptanceTest/users/OrderManagementTest/ReserveOrderTest.java
+++ b/src/main/java/AcceptanceTest/users/OrderManagementTest/ReserveOrderTest.java
@@ -1,0 +1,173 @@
+package AcceptanceTest.users.OrderManagementTest;
+import AcceptanceTest.users.initTheSystem;
+import Appliction.EventService;
+import Appliction.OrderService;
+import Appliction.UserService;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ReserveOrderTest {
+
+    private UserService userService;
+    private EventService eventService;
+    private OrderService orderService;
+    private initTheSystem initTheSystem;
+
+    private final List<String> failTests = new ArrayList<>();
+    private final List<String> passTests = new ArrayList<>();
+    private final Map<String, Supplier<Boolean>> testMap = new LinkedHashMap<>();
+
+    public ReserveOrderTest(UserService userService, EventService eventService, OrderService orderService, initTheSystem initTheSystem) {
+        this.userService = userService;
+        this.eventService = eventService;
+        this.orderService = orderService;
+        this.initTheSystem = initTheSystem;
+        initTestMap();
+    }
+
+    private void initTestMap() {
+        testMap.put("1", this::reserveOrderSuccess);
+        testMap.put("2", this::reserveOrderFailedEventNotFound);
+        testMap.put("3", this::reserveOrderFailedNotEnoughTickets);
+        testMap.put("4", this::reserveOrderFailedNotLoggedIn);
+        testMap.put("5", this::reserveOrderFailedNegativeAmount);
+        testMap.put("6", this::reserveOrderFailedZeroAmount);
+        testMap.put("7", this::reserveOrderFailedExceedUserLimit);
+        testMap.put("8", this::reserveOrderFailedSoldOut);
+        testMap.put("9", this::reserveOrderFailedEventDeleted);
+        testMap.put("10", this::reserveMultipleOrdersSuccess);
+    }
+
+    public String runAllTests() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("Reserve Order Acceptance Tests:\n");
+
+        testMap.forEach((id, testLogic) -> {
+            initTheSystem.init();
+            boolean result;
+            try {
+                result = testLogic.get();
+            } catch (Exception e) {
+                result = false;
+            }
+
+            stringBuilder.append("the result of test ").append(id).append(": ").append(result).append("\n");
+
+            if (result) passTests.add(id);
+            else failTests.add(id);
+        });
+
+        return stringBuilder.toString();
+    }
+
+    public boolean reserveOrderSuccess() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+        
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Rock Concert", "2026-10-10", "TLV", adminToken);
+
+        String result = orderService.reserveTickets(eventId, 2, token);
+        return result.startsWith("reserve_success");
+    }
+
+    public boolean reserveOrderFailedEventNotFound() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+
+        String result = orderService.reserveTickets("fake-id-999", 2, token);
+        return result.equals("failed_event_not_found");
+    }
+
+    public boolean reserveOrderFailedNotEnoughTickets() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+        
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Small Show", "2026-11-11", "Barby", adminToken);
+
+        String result = orderService.reserveTickets(eventId, 150, token);
+        return result.equals("failed_not_enough_tickets");
+    }
+
+    public boolean reserveOrderFailedNotLoggedIn() {
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Open Air", "2026-12-12", "Park", adminToken);
+
+        String result = orderService.reserveTickets(eventId, 2, "invalid-token");
+        return result.equals("failed_not_logged_in");
+    }
+
+    public boolean reserveOrderFailedNegativeAmount() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+        
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Jazz Night", "2026-08-08", "Jerusalem", adminToken);
+
+        String result = orderService.reserveTickets(eventId, -5, token);
+        return result.equals("failed_invalid_amount");
+    }
+
+    public boolean reserveOrderFailedZeroAmount() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+        
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Pop Show", "2026-09-09", "Haifa", adminToken);
+
+        String result = orderService.reserveTickets(eventId, 0, token);
+        return result.equals("failed_invalid_amount");
+    }
+
+    public boolean reserveOrderFailedExceedUserLimit() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+        
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Big Festival", "2026-07-07", "Eilat", adminToken);
+
+        String result = orderService.reserveTickets(eventId, 15, token);
+        return result.equals("failed_exceed_user_limit");
+    }
+
+    public boolean reserveOrderFailedSoldOut() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+
+        String result = orderService.reserveTickets("sold-out-id", 2, token);
+        return result.equals("failed_sold_out");
+    }
+
+    public boolean reserveOrderFailedEventDeleted() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+
+        String result = orderService.reserveTickets("deleted-id-123", 1, token);
+        return result.equals("failed_event_not_found");
+    }
+
+    public boolean reserveMultipleOrdersSuccess() {
+        userService.register("user1", "pass1");
+        String token = userService.login("user1", "pass1");
+        
+        userService.register("admin", "adminPass");
+        String adminToken = userService.login("admin", "adminPass");
+        String eventId = eventService.createEvent("Classic Concert", "2026-05-05", "Tzfat", adminToken);
+
+        String result1 = orderService.reserveTickets(eventId, 2, token);
+        String result2 = orderService.reserveTickets(eventId, 3, token);
+        
+        return result1.startsWith("reserve_success") && result2.startsWith("reserve_success");
+    }
+}

--- a/src/main/java/AcceptanceTest/users/OrderManagementTest/ReserveOrderTest.java
+++ b/src/main/java/AcceptanceTest/users/OrderManagementTest/ReserveOrderTest.java
@@ -3,6 +3,7 @@ import AcceptanceTest.users.initTheSystem;
 import Appliction.EventService;
 import Appliction.OrderService;
 import Appliction.UserService;
+import Appliction.Response;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -49,18 +50,11 @@ public class ReserveOrderTest {
         testMap.forEach((id, testLogic) -> {
             initTheSystem.init();
             boolean result;
-            try {
-                result = testLogic.get();
-            } catch (Exception e) {
-                result = false;
-            }
-
+            try { result = testLogic.get(); } 
+            catch (Exception e) { result = false; }
             stringBuilder.append("the result of test ").append(id).append(": ").append(result).append("\n");
-
-            if (result) passTests.add(id);
-            else failTests.add(id);
+            if (result) passTests.add(id); else failTests.add(id);
         });
-
         return stringBuilder.toString();
     }
 
@@ -70,18 +64,17 @@ public class ReserveOrderTest {
         
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Rock Concert", "2026-10-10", "TLV", adminToken);
+        String eventId = eventService.createEvent("Rock Concert", "2026-10-10", "TLV", adminToken).getData();
 
-        String result = orderService.reserveTickets(eventId, 2, token);
-        return result.startsWith("reserve_success");
+        Response<String> result = orderService.reserveTickets(eventId, 2, token);
+        return result.isSuccess();
     }
 
     public boolean reserveOrderFailedEventNotFound() {
         userService.register("user1", "pass1");
         String token = userService.login("user1", "pass1");
-
-        String result = orderService.reserveTickets("fake-id-999", 2, token);
-        return result.equals("failed_event_not_found");
+        Response<String> result = orderService.reserveTickets("fake-id-999", 2, token);
+        return !result.isSuccess();
     }
 
     public boolean reserveOrderFailedNotEnoughTickets() {
@@ -90,19 +83,19 @@ public class ReserveOrderTest {
         
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Small Show", "2026-11-11", "Barby", adminToken);
+        String eventId = eventService.createEvent("Small Show", "2026-11-11", "Barby", adminToken).getData();
 
-        String result = orderService.reserveTickets(eventId, 150, token);
-        return result.equals("failed_not_enough_tickets");
+        Response<String> result = orderService.reserveTickets(eventId, 150, token);
+        return !result.isSuccess();
     }
 
     public boolean reserveOrderFailedNotLoggedIn() {
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Open Air", "2026-12-12", "Park", adminToken);
+        String eventId = eventService.createEvent("Open Air", "2026-12-12", "Park", adminToken).getData();
 
-        String result = orderService.reserveTickets(eventId, 2, "invalid-token");
-        return result.equals("failed_not_logged_in");
+        Response<String> result = orderService.reserveTickets(eventId, 2, "invalid-token");
+        return !result.isSuccess();
     }
 
     public boolean reserveOrderFailedNegativeAmount() {
@@ -111,10 +104,10 @@ public class ReserveOrderTest {
         
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Jazz Night", "2026-08-08", "Jerusalem", adminToken);
+        String eventId = eventService.createEvent("Jazz Night", "2026-08-08", "Jerusalem", adminToken).getData();
 
-        String result = orderService.reserveTickets(eventId, -5, token);
-        return result.equals("failed_invalid_amount");
+        Response<String> result = orderService.reserveTickets(eventId, -5, token);
+        return !result.isSuccess();
     }
 
     public boolean reserveOrderFailedZeroAmount() {
@@ -123,10 +116,10 @@ public class ReserveOrderTest {
         
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Pop Show", "2026-09-09", "Haifa", adminToken);
+        String eventId = eventService.createEvent("Pop Show", "2026-09-09", "Haifa", adminToken).getData();
 
-        String result = orderService.reserveTickets(eventId, 0, token);
-        return result.equals("failed_invalid_amount");
+        Response<String> result = orderService.reserveTickets(eventId, 0, token);
+        return !result.isSuccess();
     }
 
     public boolean reserveOrderFailedExceedUserLimit() {
@@ -135,26 +128,24 @@ public class ReserveOrderTest {
         
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Big Festival", "2026-07-07", "Eilat", adminToken);
+        String eventId = eventService.createEvent("Big Festival", "2026-07-07", "Eilat", adminToken).getData();
 
-        String result = orderService.reserveTickets(eventId, 15, token);
-        return result.equals("failed_exceed_user_limit");
+        Response<String> result = orderService.reserveTickets(eventId, 15, token);
+        return !result.isSuccess();
     }
 
     public boolean reserveOrderFailedSoldOut() {
         userService.register("user1", "pass1");
         String token = userService.login("user1", "pass1");
-
-        String result = orderService.reserveTickets("sold-out-id", 2, token);
-        return result.equals("failed_sold_out");
+        Response<String> result = orderService.reserveTickets("sold-out-id", 2, token);
+        return !result.isSuccess();
     }
 
     public boolean reserveOrderFailedEventDeleted() {
         userService.register("user1", "pass1");
         String token = userService.login("user1", "pass1");
-
-        String result = orderService.reserveTickets("deleted-id-123", 1, token);
-        return result.equals("failed_event_not_found");
+        Response<String> result = orderService.reserveTickets("deleted-id-123", 1, token);
+        return !result.isSuccess();
     }
 
     public boolean reserveMultipleOrdersSuccess() {
@@ -163,11 +154,11 @@ public class ReserveOrderTest {
         
         userService.register("admin", "adminPass");
         String adminToken = userService.login("admin", "adminPass");
-        String eventId = eventService.createEvent("Classic Concert", "2026-05-05", "Tzfat", adminToken);
+        String eventId = eventService.createEvent("Classic Concert", "2026-05-05", "Tzfat", adminToken).getData();
 
-        String result1 = orderService.reserveTickets(eventId, 2, token);
-        String result2 = orderService.reserveTickets(eventId, 3, token);
+        Response<String> result1 = orderService.reserveTickets(eventId, 2, token);
+        Response<String> result2 = orderService.reserveTickets(eventId, 3, token);
         
-        return result1.startsWith("reserve_success") && result2.startsWith("reserve_success");
+        return result1.isSuccess() && result2.isSuccess();
     }
 }

--- a/src/main/java/Appliction/EventService.java
+++ b/src/main/java/Appliction/EventService.java
@@ -1,0 +1,71 @@
+package Appliction;
+
+//TEST PURPOSE ONLY - NOT FINAL IMPLEMENTATION!
+public class EventService {
+
+    private String lastCreatorToken = "";
+    private boolean isDeleted = false;
+
+    public String createEvent(String name, String date, String location, String token) {
+        if (token == null || token.isEmpty() || name == null || name.isEmpty() || date == null || date.isEmpty() || location == null || location.isEmpty()) {
+            return "failed";
+        }
+        if (date.equals("2020-01-01") || date.equals("invalid-date")) {
+            return "failed";
+        }
+        this.lastCreatorToken = token;
+        this.isDeleted = false;
+        return "event-12345";
+    }
+
+    public String updateEventDate(String eventId, String newDate, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        return "success";
+    }
+
+    public String updateEventName(String eventId, String newName, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        return "success";
+    }
+
+    public String updateEventLocation(String eventId, String newLocation, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        return "success";
+    }
+
+    public String deleteEvent(String eventId, String token) {
+        if (eventId.equals("fake-id-999")) {
+            return "failed";
+        }
+        if (!token.equals(this.lastCreatorToken)) {
+            return "failed_no_permission";
+        }
+        if (this.isDeleted) {
+            return "failed_already_deleted";
+        }
+        this.isDeleted = true;
+        return "success";
+    }
+
+    public String getEventInfo(String eventId) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) {
+            return "failed_not_found";
+        }
+        return "event_info_string";
+    }
+}

--- a/src/main/java/Appliction/EventService.java
+++ b/src/main/java/Appliction/EventService.java
@@ -1,5 +1,6 @@
 package Appliction;
 
+//TEST ONLY - NOT FOR PRODUCTION USE
 public class EventService {
 
     private String lastCreatorToken = "";

--- a/src/main/java/Appliction/EventService.java
+++ b/src/main/java/Appliction/EventService.java
@@ -1,6 +1,5 @@
 package Appliction;
 
-//TEST ONLY - NOT FOR PRODUCTION USE
 public class EventService {
 
     private String lastCreatorToken = "";
@@ -8,80 +7,80 @@ public class EventService {
     private boolean hasEvents = false;
     private String lastEventName = "";
 
-    public String createEvent(String name, String date, String location, String token) {
+    public Response<String> createEvent(String name, String date, String location, String token) {
         if (token == null || token.isEmpty() || name == null || name.isEmpty() || date == null || date.isEmpty() || location == null || location.isEmpty()) {
-            return "failed";
+            return new Response<>(false, "Missing fields or token", null);
         }
         if (date.equals("2020-01-01") || date.equals("invalid-date")) {
-            return "failed";
+            return new Response<>(false, "Invalid date", null);
         }
         this.lastCreatorToken = token;
         this.isDeleted = false;
         this.hasEvents = true;
         this.lastEventName = name;
-        return "event-12345";
+        return new Response<>(true, "Event created", "event-12345");
     }
 
-    public String updateEventDate(String eventId, String newDate, String token) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed";
-        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
-        return "success";
+    public Response<Void> updateEventDate(String eventId, String newDate, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) return new Response<>(false, "Event not found", null);
+        if (!token.equals(this.lastCreatorToken)) return new Response<>(false, "No permission", null);
+        return new Response<>(true, "Date updated", null);
     }
 
-    public String updateEventName(String eventId, String newName, String token) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed";
-        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
-        return "success";
+    public Response<Void> updateEventName(String eventId, String newName, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) return new Response<>(false, "Event not found", null);
+        if (!token.equals(this.lastCreatorToken)) return new Response<>(false, "No permission", null);
+        return new Response<>(true, "Name updated", null);
     }
 
-    public String updateEventLocation(String eventId, String newLocation, String token) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed";
-        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
-        return "success";
+    public Response<Void> updateEventLocation(String eventId, String newLocation, String token) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) return new Response<>(false, "Event not found", null);
+        if (!token.equals(this.lastCreatorToken)) return new Response<>(false, "No permission", null);
+        return new Response<>(true, "Location updated", null);
     }
 
-    public String deleteEvent(String eventId, String token) {
-        if (eventId.equals("fake-id-999")) return "failed";
-        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
-        if (this.isDeleted) return "failed_already_deleted";
+    public Response<Void> deleteEvent(String eventId, String token) {
+        if (eventId.equals("fake-id-999")) return new Response<>(false, "Event not found", null);
+        if (!token.equals(this.lastCreatorToken)) return new Response<>(false, "No permission", null);
+        if (this.isDeleted) return new Response<>(false, "Already deleted", null);
         this.isDeleted = true;
         this.hasEvents = false;
-        return "success";
+        return new Response<>(true, "Event deleted", null);
     }
 
-    public String getEventInfo(String eventId) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed_not_found";
-        return "event_info_string";
+    public Response<String> getEventInfo(String eventId) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) return new Response<>(false, "Event not found", null);
+        return new Response<>(true, "Success", "event_info_string");
     }
 
-    public String getAllEvents() {
-        if (!hasEvents) return "failed_empty";
-        return "List of events: " + lastEventName;
+    public Response<String> getAllEvents() {
+        if (!hasEvents) return new Response<>(false, "Empty", null);
+        return new Response<>(true, "Success", "List of events: " + lastEventName);
     }
 
-    public String searchEventsByDate(String date) {
-        if (date.equals("2030-01-01")) return "failed_not_found";
-        return "Events on " + date + ": " + lastEventName;
+    public Response<String> searchEventsByDate(String date) {
+        if (date.equals("2030-01-01")) return new Response<>(false, "Not found", null);
+        return new Response<>(true, "Success", "Events on " + date + ": " + lastEventName);
     }
 
-    public String searchEventsByCategory(String category) {
-        if (category.equals("Sports")) return "failed_not_found";
-        return "Events in " + category + ": " + lastEventName;
+    public Response<String> searchEventsByCategory(String category) {
+        if (category.equals("Sports")) return new Response<>(false, "Not found", null);
+        return new Response<>(true, "Success", "Events in " + category + ": " + lastEventName);
     }
 
-    public String searchEventsByName(String name) {
-        if (name.equals("UnknownBand")) return "failed_not_found";
-        return "Events matching " + name + ": " + lastEventName;
+    public Response<String> searchEventsByName(String name) {
+        if (name.equals("UnknownBand")) return new Response<>(false, "Not found", null);
+        return new Response<>(true, "Success", "Events matching " + name + ": " + lastEventName);
     }
 
-    public String searchEventsByLocation(String location) {
-        if (location.equals("NowhereCity")) return "failed_not_found";
-        return "Events in " + location + ": " + lastEventName;
+    public Response<String> searchEventsByLocation(String location) {
+        if (location.equals("NowhereCity")) return new Response<>(false, "Not found", null);
+        return new Response<>(true, "Success", "Events in " + location + ": " + lastEventName);
     }
 
-    public int getAvailableTickets(String eventId) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) return -1;
-        if (eventId.equals("sold-out-id")) return 0;
-        return 100;
+    public Response<Integer> getAvailableTickets(String eventId) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) return new Response<>(false, "Event not found", -1);
+        if (eventId.equals("sold-out-id")) return new Response<>(true, "Sold out", 0);
+        return new Response<>(true, "Success", 100);
     }
 }

--- a/src/main/java/Appliction/EventService.java
+++ b/src/main/java/Appliction/EventService.java
@@ -1,10 +1,11 @@
 package Appliction;
 
-//TEST PURPOSE ONLY - NOT FINAL IMPLEMENTATION!
 public class EventService {
 
     private String lastCreatorToken = "";
     private boolean isDeleted = false;
+    private boolean hasEvents = false;
+    private String lastEventName = "";
 
     public String createEvent(String name, String date, String location, String token) {
         if (token == null || token.isEmpty() || name == null || name.isEmpty() || date == null || date.isEmpty() || location == null || location.isEmpty()) {
@@ -15,57 +16,71 @@ public class EventService {
         }
         this.lastCreatorToken = token;
         this.isDeleted = false;
+        this.hasEvents = true;
+        this.lastEventName = name;
         return "event-12345";
     }
 
     public String updateEventDate(String eventId, String newDate, String token) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) {
-            return "failed";
-        }
-        if (!token.equals(this.lastCreatorToken)) {
-            return "failed_no_permission";
-        }
+        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed";
+        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
         return "success";
     }
 
     public String updateEventName(String eventId, String newName, String token) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) {
-            return "failed";
-        }
-        if (!token.equals(this.lastCreatorToken)) {
-            return "failed_no_permission";
-        }
+        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed";
+        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
         return "success";
     }
 
     public String updateEventLocation(String eventId, String newLocation, String token) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) {
-            return "failed";
-        }
-        if (!token.equals(this.lastCreatorToken)) {
-            return "failed_no_permission";
-        }
+        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed";
+        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
         return "success";
     }
 
     public String deleteEvent(String eventId, String token) {
-        if (eventId.equals("fake-id-999")) {
-            return "failed";
-        }
-        if (!token.equals(this.lastCreatorToken)) {
-            return "failed_no_permission";
-        }
-        if (this.isDeleted) {
-            return "failed_already_deleted";
-        }
+        if (eventId.equals("fake-id-999")) return "failed";
+        if (!token.equals(this.lastCreatorToken)) return "failed_no_permission";
+        if (this.isDeleted) return "failed_already_deleted";
         this.isDeleted = true;
+        this.hasEvents = false;
         return "success";
     }
 
     public String getEventInfo(String eventId) {
-        if (eventId.equals("fake-id-999") || this.isDeleted) {
-            return "failed_not_found";
-        }
+        if (eventId.equals("fake-id-999") || this.isDeleted) return "failed_not_found";
         return "event_info_string";
+    }
+
+    public String getAllEvents() {
+        if (!hasEvents) return "failed_empty";
+        return "List of events: " + lastEventName;
+    }
+
+    public String searchEventsByDate(String date) {
+        if (date.equals("2030-01-01")) return "failed_not_found";
+        return "Events on " + date + ": " + lastEventName;
+    }
+
+    public String searchEventsByCategory(String category) {
+        if (category.equals("Sports")) return "failed_not_found";
+        return "Events in " + category + ": " + lastEventName;
+    }
+
+    public String searchEventsByName(String name) {
+        if (name.equals("UnknownBand")) return "failed_not_found";
+        return "Events matching " + name + ": " + lastEventName;
+    }
+
+    public String searchEventsByLocation(String location) {
+        if (location.equals("NowhereCity")) return "failed_not_found";
+        return "Events in " + location + ": " + lastEventName;
+    }
+
+    public int getAvailableTickets(String eventId) {
+        if (eventId.equals("fake-id-999") || this.isDeleted) return -1;
+        if (eventId.equals("sold-out-id")) return 0;
+        return 100;
     }
 }

--- a/src/main/java/Appliction/OrderService.java
+++ b/src/main/java/Appliction/OrderService.java
@@ -2,25 +2,14 @@ package Appliction;
 
 public class OrderService {
 
-    public String reserveTickets(String eventId, int amount, String userToken) {
-        if (userToken == null || userToken.isEmpty() || userToken.equals("invalid-token")) {
-            return "failed_not_logged_in";
-        }
-        if (eventId.equals("fake-id-999") || eventId.equals("deleted-id-123")) {
-            return "failed_event_not_found";
-        }
-        if (eventId.equals("sold-out-id")) {
-            return "failed_sold_out";
-        }
-        if (amount <= 0) {
-            return "failed_invalid_amount";
-        }
-        if (amount > 100) {
-            return "failed_not_enough_tickets";
-        }
-        if (amount > 10) {
-            return "failed_exceed_user_limit";
-        }
-        return "reserve_success_id_555";
+    public Response<String> reserveTickets(String eventId, int amount, String userToken) {
+        if (userToken == null || userToken.isEmpty() || userToken.equals("invalid-token")) return new Response<>(false, "Not logged in", null);
+        if (eventId.equals("fake-id-999") || eventId.equals("deleted-id-123")) return new Response<>(false, "Event not found", null);
+        if (eventId.equals("sold-out-id")) return new Response<>(false, "Sold out", null);
+        if (amount <= 0) return new Response<>(false, "Invalid amount", null);
+        if (amount > 100) return new Response<>(false, "Not enough tickets", null);
+        if (amount > 10) return new Response<>(false, "Exceeded user limit", null);
+        
+        return new Response<>(true, "Reservation successful", "reserve_id_555");
     }
 }

--- a/src/main/java/Appliction/OrderService.java
+++ b/src/main/java/Appliction/OrderService.java
@@ -1,0 +1,26 @@
+package Appliction;
+
+public class OrderService {
+
+    public String reserveTickets(String eventId, int amount, String userToken) {
+        if (userToken == null || userToken.isEmpty() || userToken.equals("invalid-token")) {
+            return "failed_not_logged_in";
+        }
+        if (eventId.equals("fake-id-999") || eventId.equals("deleted-id-123")) {
+            return "failed_event_not_found";
+        }
+        if (eventId.equals("sold-out-id")) {
+            return "failed_sold_out";
+        }
+        if (amount <= 0) {
+            return "failed_invalid_amount";
+        }
+        if (amount > 100) {
+            return "failed_not_enough_tickets";
+        }
+        if (amount > 10) {
+            return "failed_exceed_user_limit";
+        }
+        return "reserve_success_id_555";
+    }
+}

--- a/src/main/java/Appliction/Response.java
+++ b/src/main/java/Appliction/Response.java
@@ -1,0 +1,25 @@
+package Appliction;
+
+public class Response<T> {
+    private final boolean success;
+    private final String message;
+    private final T data;
+
+    public Response(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+}


### PR DESCRIPTION
היי כולם,

תוך כדי עבודה על הטסטים קלטתי שאנחנו מסתמכים על טקסטים ספציפיים (כמו `"failed_not_logged_in"`) כדי להחליט אם טסט עבר או נכשל. מספיק שמישהו ישנה אות קטנה בהודעת השגיאה - וכל הטסטים יקרסו למרות שהקוד עצמו תקין.

כדי למנוע את הכאב ראש הזה בעתיד, עשיתי יישור קו:
1. הוספתי מחלקה גנרית קטנה בשם `Response<T>.
2. עדכנתי את ה-Services (ה-Dummy) שיחזירו את האובייקט הזה במקום סתם מחרוזות.


**מה זה אומר למי שמממש את הלוגיקה בהמשך?** מעכשיו פשוט תחזירו אובייקט `Response`. ככה תוכלו לכתוב איזו הודעת שגיאה שתרצו ב-Message מבלי לפחד שתשברו לנו את הטסטים. 

**איך לבדוק?**
פשוט להריץ את `AllTestRun` ולראות שהכל נשאר ירוק.