### PR TITLE
feat: integrate JaCoCo coverage reporting (#107)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,11 +1,3 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Java CI with Maven
 
 on:
@@ -27,9 +19,10 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Build with Maven
-      run: mvn -B package -DskipTests --file pom.xml
+    - name: Build and Test with Maven
+      run: mvn -B verify --file pom.xml
+    - name: Upload JaCoCo Coverage Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: jacoco-report
+        path: target/site/jacoco/


### PR DESCRIPTION
Closes #107 
-Fixed duplicate "Build with Maven" steps
-Replaced `mvn package` with `mvn verify`
-Added JaCoCo report upload as GitHub Actions artifact
-pom.xml was already correctly configured, no changes needed