### PR TITLE
feat: system initialization and external services REST API with tests

### DIFF
--- a/src/main/java/com/ticketing/ticketapp/Appliction/SystemService.java
+++ b/src/main/java/com/ticketing/ticketapp/Appliction/SystemService.java
@@ -1,0 +1,84 @@
+package com.ticketing.ticketapp.Appliction;
+
+import com.ticketing.ticketapp.Domain.AdminAggregate.iAdminRepository;
+import com.ticketing.ticketapp.Infastructure.TokenService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SystemService {
+
+    private final UserService userService;
+    private final TokenService tokenService;
+    private final iAdminRepository adminRepository;
+    private final IPaymentService paymentService;
+    private final ISupplyService supplyService;
+
+    private volatile boolean initialized = false;
+    private volatile boolean open = false;
+
+    public SystemService(UserService userService, TokenService tokenService,
+                         iAdminRepository adminRepository,
+                         IPaymentService paymentService,
+                         ISupplyService supplyService) {
+        this.userService = userService;
+        this.tokenService = tokenService;
+        this.adminRepository = adminRepository;
+        this.paymentService = paymentService;
+        this.supplyService = supplyService;
+    }
+
+    public Response<String> initSystem(String token, String adminUsername, String adminPassword,
+                                       int adminAge, String adminEmail) {
+        if (initialized) {
+            return Response.error("System already initialized");
+        }
+
+        boolean paymentOk = paymentService.processPayment("0000000000000000", 0.0);
+        boolean supplyOk = supplyService.supplyToEmail("system@check.internal", "ping");
+        if (!paymentOk || !supplyOk) {
+            return Response.error("External services unavailable");
+        }
+
+        Response<String> registerResp = userService.register(token, adminUsername, adminPassword, adminAge, adminEmail);
+        if (registerResp.isError()) {
+            return Response.error("Failed to create admin: " + registerResp.getMessage());
+        }
+
+        String loginGuestToken = tokenService.generateGuestToken();
+        Response<String> loginResp = userService.login(loginGuestToken, adminUsername, adminPassword);
+        if (loginResp.isError()) {
+            return Response.error("Failed to authenticate admin after creation");
+        }
+
+        String adminUserId = tokenService.extractUserId(loginResp.getData());
+        adminRepository.addAdmin(adminUserId);
+        initialized = true;
+
+        return Response.success("System initialized successfully. Admin '" + adminUsername + "' created.");
+    }
+
+    public Response<String> openSystem(String token) {
+        if (!initialized) {
+            return Response.error("System must be initialized before opening");
+        }
+        if (open) {
+            return Response.error("System is already open");
+        }
+
+        String userId = tokenService.extractUserId(token);
+        if (!adminRepository.isAdmin(userId)) {
+            return Response.error("Unauthorized: admin access required to open the system");
+        }
+
+        open = true;
+        return Response.success("System is now open");
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public boolean isOpen() {
+        return open;
+    }
+}

--- a/src/main/java/com/ticketing/ticketapp/Controllers/SystemController.java
+++ b/src/main/java/com/ticketing/ticketapp/Controllers/SystemController.java
@@ -1,0 +1,135 @@
+package com.ticketing.ticketapp.Controllers;
+
+import com.ticketing.ticketapp.Appliction.IPaymentService;
+import com.ticketing.ticketapp.Appliction.ISupplyService;
+import com.ticketing.ticketapp.Appliction.Response;
+import com.ticketing.ticketapp.Appliction.SystemService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/system")
+public class SystemController {
+
+    private final SystemService systemService;
+    private final IPaymentService paymentService;
+    private final ISupplyService supplyService;
+
+    public SystemController(SystemService systemService, IPaymentService paymentService,
+                            ISupplyService supplyService) {
+        this.systemService = systemService;
+        this.paymentService = paymentService;
+        this.supplyService = supplyService;
+    }
+
+    @PostMapping("/init")
+    public ResponseEntity<?> initSystem(
+            @RequestAttribute("cleanToken") String token,
+            @RequestBody InitRequest request) {
+
+        Response<String> response = systemService.initSystem(
+                token,
+                request.getAdminUsername(),
+                request.getAdminPassword(),
+                request.getAdminAge(),
+                request.getAdminEmail()
+        );
+
+        if (response.isSuccess()) {
+            return ResponseEntity.ok(Map.of("message", response.getData()));
+        }
+        return ResponseEntity.badRequest().body(Map.of("error", response.getMessage()));
+    }
+
+    @PostMapping("/open")
+    public ResponseEntity<?> openSystem(
+            @RequestAttribute("cleanToken") String token) {
+
+        Response<String> response = systemService.openSystem(token);
+
+        if (response.isSuccess()) {
+            return ResponseEntity.ok(Map.of("message", response.getData()));
+        }
+        return ResponseEntity.badRequest().body(Map.of("error", response.getMessage()));
+    }
+
+    @PostMapping("/external/payment")
+    public ResponseEntity<?> processPayment(
+            @RequestAttribute("cleanToken") String token,
+            @RequestBody PaymentRequest request) {
+
+        boolean result = paymentService.processPayment(request.getCreditCardDetails(), request.getAmount());
+        if (result) {
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "transactionId", "TXN-" + UUID.randomUUID()
+            ));
+        }
+        return ResponseEntity.badRequest().body(Map.of(
+                "success", false,
+                "error", "Payment declined"
+        ));
+    }
+
+    @PostMapping("/external/supply")
+    public ResponseEntity<?> supplyTicket(
+            @RequestAttribute("cleanToken") String token,
+            @RequestBody SupplyRequest request) {
+
+        boolean result = supplyService.supplyToEmail(request.getEmailAddress(), request.getContent());
+        if (result) {
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "message", "Ticket delivered to " + request.getEmailAddress()
+            ));
+        }
+        return ResponseEntity.badRequest().body(Map.of(
+                "success", false,
+                "error", "Supply failed"
+        ));
+    }
+
+    public static class InitRequest {
+        private String adminUsername;
+        private String adminPassword;
+        private int adminAge;
+        private String adminEmail;
+
+        public String getAdminUsername() { return adminUsername; }
+        public void setAdminUsername(String adminUsername) { this.adminUsername = adminUsername; }
+
+        public String getAdminPassword() { return adminPassword; }
+        public void setAdminPassword(String adminPassword) { this.adminPassword = adminPassword; }
+
+        public int getAdminAge() { return adminAge; }
+        public void setAdminAge(int adminAge) { this.adminAge = adminAge; }
+
+        public String getAdminEmail() { return adminEmail; }
+        public void setAdminEmail(String adminEmail) { this.adminEmail = adminEmail; }
+    }
+
+    public static class PaymentRequest {
+        private String creditCardDetails;
+        private double amount;
+
+        public String getCreditCardDetails() { return creditCardDetails; }
+        public void setCreditCardDetails(String creditCardDetails) { this.creditCardDetails = creditCardDetails; }
+
+        public double getAmount() { return amount; }
+        public void setAmount(double amount) { this.amount = amount; }
+    }
+
+    public static class SupplyRequest {
+        private String emailAddress;
+        private String content;
+
+        public String getEmailAddress() { return emailAddress; }
+        public void setEmailAddress(String emailAddress) { this.emailAddress = emailAddress; }
+
+        public String getContent() { return content; }
+        public void setContent(String content) { this.content = content; }
+    }
+}

--- a/src/test/java/Appliction/SystemServiceTest.java
+++ b/src/test/java/Appliction/SystemServiceTest.java
@@ -1,0 +1,205 @@
+package Appliction;
+
+import com.ticketing.ticketapp.Appliction.IPaymentService;
+import com.ticketing.ticketapp.Appliction.ISupplyService;
+import com.ticketing.ticketapp.Appliction.Response;
+import com.ticketing.ticketapp.Appliction.SystemService;
+import com.ticketing.ticketapp.Appliction.UserService;
+import com.ticketing.ticketapp.Domain.AdminAggregate.iAdminRepository;
+import com.ticketing.ticketapp.Infastructure.TokenService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SystemServiceTest {
+
+    @Mock private UserService userService;
+    @Mock private TokenService tokenService;
+    @Mock private iAdminRepository adminRepository;
+    @Mock private IPaymentService paymentService;
+    @Mock private ISupplyService supplyService;
+
+    @InjectMocks private SystemService systemService;
+
+    private static final String GUEST_TOKEN     = "guest-token";
+    private static final String LOGIN_TOKEN     = "login-guest-token";
+    private static final String ADMIN_JWT       = "admin-jwt";
+    private static final String ADMIN_TOKEN     = "admin-token";
+    private static final String ADMIN_USER_ID   = "admin-uuid-123";
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private void stubSuccessfulInit() {
+        when(paymentService.processPayment(anyString(), anyDouble())).thenReturn(true);
+        when(supplyService.supplyToEmail(anyString(), anyString())).thenReturn(true);
+        when(userService.register(eq(GUEST_TOKEN), anyString(), anyString(), anyInt(), anyString()))
+                .thenReturn(Response.success("registered"));
+        when(tokenService.generateGuestToken()).thenReturn(LOGIN_TOKEN);
+        when(userService.login(eq(LOGIN_TOKEN), anyString(), anyString()))
+                .thenReturn(Response.success(ADMIN_JWT));
+        when(tokenService.extractUserId(ADMIN_JWT)).thenReturn(ADMIN_USER_ID);
+    }
+
+    private void performInit() {
+        stubSuccessfulInit();
+        systemService.initSystem(GUEST_TOKEN, "admin", "pass123", 30, "admin@test.com");
+    }
+
+    private void performOpen() {
+        when(tokenService.extractUserId(ADMIN_TOKEN)).thenReturn(ADMIN_USER_ID);
+        when(adminRepository.isAdmin(ADMIN_USER_ID)).thenReturn(true);
+        systemService.openSystem(ADMIN_TOKEN);
+    }
+
+    // ── initSystem ───────────────────────────────────────────────────────────
+
+    @Test
+    void initSystem_Success_SetsInitializedAndRegistersAdmin() {
+        stubSuccessfulInit();
+
+        Response<String> result = systemService.initSystem(GUEST_TOKEN, "admin", "pass123", 30, "admin@test.com");
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.getData().contains("admin"));
+        assertTrue(systemService.isInitialized());
+        verify(adminRepository).addAdmin(ADMIN_USER_ID);
+    }
+
+    @Test
+    void initSystem_AlreadyInitialized_ReturnsError() {
+        performInit();
+
+        Response<String> result = systemService.initSystem(GUEST_TOKEN, "admin2", "pass", 25, "a@b.com");
+
+        assertFalse(result.isSuccess());
+        assertEquals("System already initialized", result.getMessage());
+        // admin repo must not be called a second time
+        verify(adminRepository, times(1)).addAdmin(any());
+    }
+
+    @Test
+    void initSystem_PaymentServiceUnavailable_ReturnsError() {
+        when(paymentService.processPayment(anyString(), anyDouble())).thenReturn(false);
+        when(supplyService.supplyToEmail(anyString(), anyString())).thenReturn(true);
+
+        Response<String> result = systemService.initSystem(GUEST_TOKEN, "admin", "pass", 30, "a@b.com");
+
+        assertFalse(result.isSuccess());
+        assertEquals("External services unavailable", result.getMessage());
+        assertFalse(systemService.isInitialized());
+        verify(adminRepository, never()).addAdmin(any());
+    }
+
+    @Test
+    void initSystem_SupplyServiceUnavailable_ReturnsError() {
+        when(paymentService.processPayment(anyString(), anyDouble())).thenReturn(true);
+        when(supplyService.supplyToEmail(anyString(), anyString())).thenReturn(false);
+
+        Response<String> result = systemService.initSystem(GUEST_TOKEN, "admin", "pass", 30, "a@b.com");
+
+        assertFalse(result.isSuccess());
+        assertEquals("External services unavailable", result.getMessage());
+        assertFalse(systemService.isInitialized());
+        verify(adminRepository, never()).addAdmin(any());
+    }
+
+    @Test
+    void initSystem_AdminRegistrationFails_ReturnsError() {
+        when(paymentService.processPayment(anyString(), anyDouble())).thenReturn(true);
+        when(supplyService.supplyToEmail(anyString(), anyString())).thenReturn(true);
+        when(userService.register(anyString(), anyString(), anyString(), anyInt(), anyString()))
+                .thenReturn(Response.error("Username already taken"));
+
+        Response<String> result = systemService.initSystem(GUEST_TOKEN, "admin", "pass", 30, "a@b.com");
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getMessage().contains("Failed to create admin"));
+        assertFalse(systemService.isInitialized());
+        verify(adminRepository, never()).addAdmin(any());
+    }
+
+    @Test
+    void initSystem_AdminLoginFails_ReturnsError() {
+        when(paymentService.processPayment(anyString(), anyDouble())).thenReturn(true);
+        when(supplyService.supplyToEmail(anyString(), anyString())).thenReturn(true);
+        when(userService.register(eq(GUEST_TOKEN), anyString(), anyString(), anyInt(), anyString()))
+                .thenReturn(Response.success("registered"));
+        when(tokenService.generateGuestToken()).thenReturn(LOGIN_TOKEN);
+        when(userService.login(eq(LOGIN_TOKEN), anyString(), anyString()))
+                .thenReturn(Response.error("Login failed"));
+
+        Response<String> result = systemService.initSystem(GUEST_TOKEN, "admin", "pass", 30, "a@b.com");
+
+        assertFalse(result.isSuccess());
+        assertEquals("Failed to authenticate admin after creation", result.getMessage());
+        assertFalse(systemService.isInitialized());
+        verify(adminRepository, never()).addAdmin(any());
+    }
+
+    // ── openSystem ───────────────────────────────────────────────────────────
+
+    @Test
+    void openSystem_NotInitialized_ReturnsError() {
+        Response<String> result = systemService.openSystem(ADMIN_TOKEN);
+
+        assertFalse(result.isSuccess());
+        assertEquals("System must be initialized before opening", result.getMessage());
+        assertFalse(systemService.isOpen());
+    }
+
+    @Test
+    void openSystem_NotAdmin_ReturnsError() {
+        performInit();
+        when(tokenService.extractUserId(ADMIN_TOKEN)).thenReturn("other-user-id");
+        when(adminRepository.isAdmin("other-user-id")).thenReturn(false);
+
+        Response<String> result = systemService.openSystem(ADMIN_TOKEN);
+
+        assertFalse(result.isSuccess());
+        assertEquals("Unauthorized: admin access required to open the system", result.getMessage());
+        assertFalse(systemService.isOpen());
+    }
+
+    @Test
+    void openSystem_Success_SetsOpenState() {
+        performInit();
+        when(tokenService.extractUserId(ADMIN_TOKEN)).thenReturn(ADMIN_USER_ID);
+        when(adminRepository.isAdmin(ADMIN_USER_ID)).thenReturn(true);
+
+        Response<String> result = systemService.openSystem(ADMIN_TOKEN);
+
+        assertTrue(result.isSuccess());
+        assertEquals("System is now open", result.getData());
+        assertTrue(systemService.isOpen());
+    }
+
+    @Test
+    void openSystem_AlreadyOpen_ReturnsError() {
+        performInit();
+        performOpen();
+
+        Response<String> result = systemService.openSystem(ADMIN_TOKEN);
+
+        assertFalse(result.isSuccess());
+        assertEquals("System is already open", result.getMessage());
+    }
+
+    // ── getters ──────────────────────────────────────────────────────────────
+
+    @Test
+    void isInitialized_DefaultsFalse() {
+        assertFalse(systemService.isInitialized());
+    }
+
+    @Test
+    void isOpen_DefaultsFalse() {
+        assertFalse(systemService.isOpen());
+    }
+}

--- a/src/test/java/Controllers/SystemControllerTest.java
+++ b/src/test/java/Controllers/SystemControllerTest.java
@@ -1,0 +1,206 @@
+package Controllers;
+
+import com.ticketing.ticketapp.Appliction.IPaymentService;
+import com.ticketing.ticketapp.Appliction.ISupplyService;
+import com.ticketing.ticketapp.Appliction.Response;
+import com.ticketing.ticketapp.Appliction.SystemService;
+import com.ticketing.ticketapp.Controllers.SystemController;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SystemControllerTest {
+
+    @Mock
+    private SystemService systemService;
+
+    @Mock
+    private IPaymentService paymentService;
+
+    @Mock
+    private ISupplyService supplyService;
+
+    @InjectMocks
+    private SystemController systemController;
+
+    private static final String TOKEN = "test-token";
+
+    // ── /init ────────────────────────────────────────────────────────────────
+
+    @Test
+    void init_Success_Returns200() {
+        when(systemService.initSystem(TOKEN, "admin", "pass123", 30, "admin@test.com"))
+                .thenReturn(Response.success("System initialized successfully. Admin 'admin' created."));
+
+        SystemController.InitRequest request = new SystemController.InitRequest();
+        request.setAdminUsername("admin");
+        request.setAdminPassword("pass123");
+        request.setAdminAge(30);
+        request.setAdminEmail("admin@test.com");
+
+        ResponseEntity<?> response = systemController.initSystem(TOKEN, request);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("System initialized successfully. Admin 'admin' created.",
+                ((Map<?, ?>) response.getBody()).get("message"));
+    }
+
+    @Test
+    void init_AlreadyInitialized_Returns400() {
+        when(systemService.initSystem(anyString(), anyString(), anyString(), anyInt(), anyString()))
+                .thenReturn(Response.error("System already initialized"));
+
+        SystemController.InitRequest request = new SystemController.InitRequest();
+        request.setAdminUsername("admin");
+        request.setAdminPassword("pass123");
+        request.setAdminAge(30);
+        request.setAdminEmail("admin@test.com");
+
+        ResponseEntity<?> response = systemController.initSystem(TOKEN, request);
+
+        assertEquals(400, response.getStatusCode().value());
+        assertEquals("System already initialized", ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
+    @Test
+    void init_ExternalServiceUnavailable_Returns400() {
+        when(systemService.initSystem(anyString(), anyString(), anyString(), anyInt(), anyString()))
+                .thenReturn(Response.error("External services unavailable"));
+
+        SystemController.InitRequest request = new SystemController.InitRequest();
+        request.setAdminUsername("admin");
+        request.setAdminPassword("pass123");
+        request.setAdminAge(30);
+        request.setAdminEmail("admin@test.com");
+
+        ResponseEntity<?> response = systemController.initSystem(TOKEN, request);
+
+        assertEquals(400, response.getStatusCode().value());
+        assertEquals("External services unavailable", ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
+    // ── /open ────────────────────────────────────────────────────────────────
+
+    @Test
+    void open_Success_Returns200() {
+        when(systemService.openSystem(TOKEN)).thenReturn(Response.success("System is now open"));
+
+        ResponseEntity<?> response = systemController.openSystem(TOKEN);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("System is now open", ((Map<?, ?>) response.getBody()).get("message"));
+    }
+
+    @Test
+    void open_NotInitialized_Returns400() {
+        when(systemService.openSystem(TOKEN))
+                .thenReturn(Response.error("System must be initialized before opening"));
+
+        ResponseEntity<?> response = systemController.openSystem(TOKEN);
+
+        assertEquals(400, response.getStatusCode().value());
+        assertEquals("System must be initialized before opening",
+                ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
+    @Test
+    void open_NotAdmin_Returns400() {
+        when(systemService.openSystem(TOKEN))
+                .thenReturn(Response.error("Unauthorized: admin access required to open the system"));
+
+        ResponseEntity<?> response = systemController.openSystem(TOKEN);
+
+        assertEquals(400, response.getStatusCode().value());
+        assertEquals("Unauthorized: admin access required to open the system",
+                ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
+    @Test
+    void open_AlreadyOpen_Returns400() {
+        when(systemService.openSystem(TOKEN)).thenReturn(Response.error("System is already open"));
+
+        ResponseEntity<?> response = systemController.openSystem(TOKEN);
+
+        assertEquals(400, response.getStatusCode().value());
+        assertEquals("System is already open", ((Map<?, ?>) response.getBody()).get("error"));
+    }
+
+    // ── /external/payment ────────────────────────────────────────────────────
+
+    @Test
+    void processPayment_Approved_Returns200WithTransactionId() {
+        when(paymentService.processPayment("4111111111111111", 99.99)).thenReturn(true);
+
+        SystemController.PaymentRequest request = new SystemController.PaymentRequest();
+        request.setCreditCardDetails("4111111111111111");
+        request.setAmount(99.99);
+
+        ResponseEntity<?> response = systemController.processPayment(TOKEN, request);
+
+        assertEquals(200, response.getStatusCode().value());
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertEquals(true, body.get("success"));
+        assertNotNull(body.get("transactionId"));
+        assertTrue(body.get("transactionId").toString().startsWith("TXN-"));
+    }
+
+    @Test
+    void processPayment_Declined_Returns400() {
+        when(paymentService.processPayment(anyString(), anyDouble())).thenReturn(false);
+
+        SystemController.PaymentRequest request = new SystemController.PaymentRequest();
+        request.setCreditCardDetails("0000000000000000");
+        request.setAmount(50.0);
+
+        ResponseEntity<?> response = systemController.processPayment(TOKEN, request);
+
+        assertEquals(400, response.getStatusCode().value());
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertEquals(false, body.get("success"));
+        assertEquals("Payment declined", body.get("error"));
+    }
+
+    // ── /external/supply ─────────────────────────────────────────────────────
+
+    @Test
+    void supplyTicket_Success_Returns200() {
+        when(supplyService.supplyToEmail("user@test.com", "Your ticket")).thenReturn(true);
+
+        SystemController.SupplyRequest request = new SystemController.SupplyRequest();
+        request.setEmailAddress("user@test.com");
+        request.setContent("Your ticket");
+
+        ResponseEntity<?> response = systemController.supplyTicket(TOKEN, request);
+
+        assertEquals(200, response.getStatusCode().value());
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertEquals(true, body.get("success"));
+        assertEquals("Ticket delivered to user@test.com", body.get("message"));
+    }
+
+    @Test
+    void supplyTicket_Failure_Returns400() {
+        when(supplyService.supplyToEmail(anyString(), anyString())).thenReturn(false);
+
+        SystemController.SupplyRequest request = new SystemController.SupplyRequest();
+        request.setEmailAddress("user@test.com");
+        request.setContent("Your ticket");
+
+        ResponseEntity<?> response = systemController.supplyTicket(TOKEN, request);
+
+        assertEquals(400, response.getStatusCode().value());
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertEquals(false, body.get("success"));
+        assertEquals("Supply failed", body.get("error"));
+    }
+}


### PR DESCRIPTION
Closes #106

- Created SystemController with 4 endpoints:
  - POST /api/system/init — initialize platform, creates first admin, probes external services
  - POST /api/system/open — open system to valid state (admin only)
  - POST /api/system/external/payment — mock payment/clearing gateway
  - POST /api/system/external/supply — mock ticket supply service
- Created SystemService with initialization and open system logic
- Created SystemControllerTest (11 tests) and SystemServiceTest (12 tests)
- SystemService at 100% branch coverage