### PR TITLE
feat: active error processing for defective responses and rollback ex…

### DIFF
--- a/src/main/java/com/ticketing/ticketapp/Appliction/PurchasedService.java
+++ b/src/main/java/com/ticketing/ticketapp/Appliction/PurchasedService.java
@@ -20,6 +20,7 @@ import com.ticketing.ticketapp.Domain.Ticket.Ticket;
 import com.ticketing.ticketapp.Domain.Ticket.TicketDTO;
 import com.ticketing.ticketapp.Domain.Ticket.iTicketRepository;
 import com.ticketing.ticketapp.Domain.payment.CreditCardDetails;
+import com.ticketing.ticketapp.Infastructure.ExternalServiceException;
 import com.ticketing.ticketapp.Infastructure.TokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,9 +127,6 @@ public class PurchasedService {
                     .sum();
 
             int transactionID = paymentService.processPayment(paymentDetails, totalPriceAfterDiscounts, "USD");
-            if (transactionID == -1) {
-                throw new PurchaseOrderException("Payment failed");
-            }
 
             List<String> externalTicketCodes = new ArrayList<>();
             try {
@@ -136,13 +134,6 @@ public class PurchasedService {
                 for (Ticket t : purchasedTickets) {
                     String ticketCode = externalTicketService.issueTicket(
                             customerId, t.getEvent(), t.getEvent(), t.getRow(), t.getCol());
-                    if (ticketCode == null || ticketCode.equals("-1")) {
-                        for (String code : externalTicketCodes) {
-                            externalTicketService.cancelTicket(code);
-                        }
-                        paymentService.refund(transactionID);
-                        throw new PurchaseOrderException("External ticket issuance failed");
-                    }
                     externalTicketCodes.add(ticketCode);
                 }
 
@@ -164,9 +155,17 @@ public class PurchasedService {
                 throw e;
             } catch (Exception e) {
                 for (String code : externalTicketCodes) {
-                    externalTicketService.cancelTicket(code);
+                    try {
+                        externalTicketService.cancelTicket(code);
+                    } catch (ExternalServiceException ex) {
+                        logger.error("Failed to cancel external ticket {} during rollback: {}", code, ex.getMessage());
+                    }
                 }
-                paymentService.refund(transactionID);
+                try {
+                    paymentService.refund(transactionID);
+                } catch (ExternalServiceException ex) {
+                    logger.error("Failed to refund transaction {} during rollback: {}", transactionID, ex.getMessage());
+                }
                 throw new PurchaseOrderException("Failed during save or supply: " + e.getMessage(), e);
             }
 
@@ -194,6 +193,9 @@ public class PurchasedService {
         } catch (PurchaseOrderException e) {
             logger.error("Transaction aborted: " + e.getMessage());
             throw e;
+        } catch (ExternalServiceException e) {
+            logger.error("External service error during purchase: {}", e.getMessage());
+            throw new PurchaseOrderException("External service error: " + e.getMessage(), e);
         } catch (Exception e) {
             logger.error(e.getMessage());
             return Response.error(e.getMessage());

--- a/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalPaymentService.java
+++ b/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalPaymentService.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,10 +18,6 @@ public class ExternalPaymentService implements IPaymentService {
     public void setApiUrl(String apiUrl) {
         this.API_URL = apiUrl;
     }
-
-    private final HttpClient client = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(3))
-            .build();
 
     @Override
     public int processPayment(CreditCardDetails cardDetails, double amount, String currency) {
@@ -51,12 +46,16 @@ public class ExternalPaymentService implements IPaymentService {
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            int result = Integer.parseInt(response.body().trim());
+            if (result == -1) {
+                throw new ExternalServiceException("Payment service returned error: -1");
+            }
+            return result;
 
-            return Integer.parseInt(response.body().trim());
-
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (Exception e) {
-            e.printStackTrace();
-            return -1;
+            throw new ExternalServiceException("Payment service error: " + e.getMessage(), e);
         }
     }
 
@@ -74,14 +73,16 @@ public class ExternalPaymentService implements IPaymentService {
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            return Integer.parseInt(response.body().trim());
+            int result = Integer.parseInt(response.body().trim());
+            if (result == -1) {
+                throw new ExternalServiceException("Payment refund service returned error: -1");
+            }
+            return result;
 
-        } catch (HttpTimeoutException e) {
-            System.err.println("[ExternalPaymentService] Timed Out! (Limit reached)");
-            return -1;
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (Exception e) {
-            System.err.println("[ExternalPaymentService] Network error or timeout: " + e.getMessage());
-            return -1;
+            throw new ExternalServiceException("Payment refund service error: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalServiceException.java
+++ b/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalServiceException.java
@@ -1,0 +1,11 @@
+package com.ticketing.ticketapp.Infastructure;
+
+public class ExternalServiceException extends RuntimeException {
+    public ExternalServiceException(String message) {
+        super(message);
+    }
+
+    public ExternalServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalTicketService.java
+++ b/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalTicketService.java
@@ -8,7 +8,6 @@ import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
@@ -20,10 +19,6 @@ public class ExternalTicketService implements IExternalTicketService {
     public void setApiUrl(String apiUrl) {
         this.API_URL = apiUrl;
     }
-
-    private final HttpClient client = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(3))
-            .build();
 
     @Override
     public String issueTicket(String customerId, String eventId, String zone, int row, int seat) {
@@ -47,15 +42,17 @@ public class ExternalTicketService implements IExternalTicketService {
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            System.out.println("[ExternalTicketService] issueTicket response: " + response.body());
-            return response.body().trim();
+            String body = response.body().trim();
+            System.out.println("[ExternalTicketService] issueTicket response: " + body);
+            if (body.equals("-1")) {
+                throw new ExternalServiceException("Ticket service returned error: -1");
+            }
+            return body;
 
-        } catch (HttpTimeoutException e) {
-            System.err.println("[ExternalTicketService] issueTicket Timed Out!");
-            return "-1";
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (Exception e) {
-            System.err.println("[ExternalTicketService] issueTicket error: " + e.getMessage());
-            return "-1";
+            throw new ExternalServiceException("Ticket service issueTicket error: " + e.getMessage(), e);
         }
     }
 
@@ -77,14 +74,16 @@ public class ExternalTicketService implements IExternalTicketService {
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             System.out.println("[ExternalTicketService] cancelTicket response: " + response.body());
-            return Integer.parseInt(response.body().trim()) == 1;
+            int result = Integer.parseInt(response.body().trim());
+            if (result == -1) {
+                throw new ExternalServiceException("Ticket cancel service returned error: -1");
+            }
+            return result == 1;
 
-        } catch (HttpTimeoutException e) {
-            System.err.println("[ExternalTicketService] cancelTicket Timed Out!");
-            return false;
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (Exception e) {
-            System.err.println("[ExternalTicketService] cancelTicket error: " + e.getMessage());
-            return false;
+            throw new ExternalServiceException("Ticket service cancelTicket error: " + e.getMessage(), e);
         }
     }
 }

--- a/src/test/java/Appliction/PurchasedServiceTest.java
+++ b/src/test/java/Appliction/PurchasedServiceTest.java
@@ -9,6 +9,7 @@ import com.ticketing.ticketapp.Domain.OwnerManagerTree.iTreeOfRoleRepository;
 import com.ticketing.ticketapp.Domain.PurchasedOrderAggregate.PurchaseOrder;
 import com.ticketing.ticketapp.Domain.PurchasedOrderAggregate.PurchaseOrderDTO;
 import com.ticketing.ticketapp.Domain.PurchasedOrderAggregate.PurchaseOrderException;
+import com.ticketing.ticketapp.Infastructure.ExternalServiceException;
 import com.ticketing.ticketapp.Domain.PurchasedOrderAggregate.iPurchasedOrderRepository;
 
 import com.ticketing.ticketapp.Domain.Ticket.Ticket;
@@ -171,12 +172,13 @@ class PurchasedServiceTest {
         String ticketId = ticketRepoSpy.getTicketsForEvent(COMPANY, EVENT).get(0).getId();
         String orderId = orderRepoSpy.store(COMPANY, EVENT, List.of(ticketId), USERNAME, futureDate);
 
-        when(paymentService.processPayment(createCreditCardDetails(), 100.0,"USD")).thenReturn(-1);
+        doThrow(new ExternalServiceException("Payment service returned error: -1"))
+                .when(paymentService).processPayment(createCreditCardDetails(), 100.0, "USD");
 
         PurchaseOrderException exception = assertThrows(PurchaseOrderException.class, () -> {
             purchasedService.PurchaseTicket(EMAIL, orderId, USERNAME, "none",createCreditCardDetails());
         });
-        assertEquals("Payment failed", exception.getMessage());
+        assertEquals("External service error: Payment service returned error: -1", exception.getMessage());
         verify(paymentService).processPayment(createCreditCardDetails(), 100.0,"USD");
         verify(supplyService, never()).supplyToEmail(anyString(), anyString());
 

--- a/src/test/java/Infastructure/ExternalServicesNegativeResponseTest.java
+++ b/src/test/java/Infastructure/ExternalServicesNegativeResponseTest.java
@@ -1,0 +1,93 @@
+package Infastructure;
+
+import com.sun.net.httpserver.HttpServer;
+import com.ticketing.ticketapp.Domain.payment.CreditCardDetails;
+import com.ticketing.ticketapp.Infastructure.ExternalPaymentService;
+import com.ticketing.ticketapp.Infastructure.ExternalServiceException;
+import com.ticketing.ticketapp.Infastructure.ExternalTicketService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that gateways throw ExternalServiceException when the external API
+ * responds with a payload of "-1", rather than silently returning a sentinel value.
+ */
+public class ExternalServicesNegativeResponseTest {
+
+    private HttpServer server;
+    private String serverUrl;
+
+    private ExternalPaymentService paymentService;
+    private ExternalTicketService ticketService;
+
+    @BeforeEach
+    public void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            byte[] body = "-1".getBytes();
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+
+        int port = server.getAddress().getPort();
+        serverUrl = "http://localhost:" + port + "/";
+
+        paymentService = new ExternalPaymentService();
+        paymentService.setApiUrl(serverUrl);
+
+        ticketService = new ExternalTicketService();
+        ticketService.setApiUrl(serverUrl);
+    }
+
+    @AfterEach
+    public void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void processPayment_WhenApiReturnsMinusOne_ThrowsExternalServiceException() {
+        CreditCardDetails card = new CreditCardDetails(
+                "1234567812345678", "12", "2026", "John Doe", "123", "123456789");
+
+        ExternalServiceException ex = assertThrows(ExternalServiceException.class,
+                () -> paymentService.processPayment(card, 100.0, "USD"));
+
+        assertTrue(ex.getMessage().contains("-1"));
+    }
+
+    @Test
+    public void refund_WhenApiReturnsMinusOne_ThrowsExternalServiceException() {
+        ExternalServiceException ex = assertThrows(ExternalServiceException.class,
+                () -> paymentService.refund(42));
+
+        assertTrue(ex.getMessage().contains("-1"));
+    }
+
+    @Test
+    public void issueTicket_WhenApiReturnsMinusOne_ThrowsExternalServiceException() {
+        ExternalServiceException ex = assertThrows(ExternalServiceException.class,
+                () -> ticketService.issueTicket("user1", "event1", "A", 1, 1));
+
+        assertTrue(ex.getMessage().contains("-1"));
+    }
+
+    @Test
+    public void cancelTicket_WhenApiReturnsMinusOne_ThrowsExternalServiceException() {
+        ExternalServiceException ex = assertThrows(ExternalServiceException.class,
+                () -> ticketService.cancelTicket("ticket-abc"));
+
+        assertTrue(ex.getMessage().contains("-1"));
+    }
+}

--- a/src/test/java/Infastructure/ExternalServicesTimeoutTest.java
+++ b/src/test/java/Infastructure/ExternalServicesTimeoutTest.java
@@ -1,13 +1,13 @@
 package Infastructure;
 
 import com.ticketing.ticketapp.Infastructure.ExternalPaymentService;
+import com.ticketing.ticketapp.Infastructure.ExternalServiceException;
 import com.ticketing.ticketapp.Infastructure.ExternalTicketService;
 import com.ticketing.ticketapp.Domain.payment.CreditCardDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExternalServicesTimeoutTest {
@@ -17,7 +17,6 @@ public class ExternalServicesTimeoutTest {
 
     private static final String SLOW_API_URL = "https://httpstat.us/200?sleep=10000";
 
-    
     @BeforeEach
     public void setup() {
         paymentService = new ExternalPaymentService();
@@ -28,25 +27,26 @@ public class ExternalServicesTimeoutTest {
     }
 
     @Test
-    public void testProcessPayment_ThrowsTimeout_AndReturnsMinusOne() {
+    public void testProcessPayment_ThrowsTimeout_AndThrowsExternalServiceException() {
         CreditCardDetails mockCard = new CreditCardDetails("1234567812345678", "12", "2026", "John Doe", "123", "123456789");
-        
+
         long startTime = System.currentTimeMillis();
-        int result = paymentService.processPayment(mockCard, 100.0, "USD");
+        assertThrows(ExternalServiceException.class,
+                () -> paymentService.processPayment(mockCard, 100.0, "USD"),
+                "A timeout should throw ExternalServiceException");
         long endTime = System.currentTimeMillis();
 
-        // timeout was set to 5 seconds, so we expect the total time to be less than 6 seconds 
         assertTrue((endTime - startTime) < 6000, "The request took too long! Timeout limit was bypassed.");
-        assertEquals(-1, result, "A timeout exception should have been caught, returning -1.");
     }
 
     @Test
-    public void testCancelTicket_ThrowsTimeout_AndReturnsFalse() {
+    public void testCancelTicket_ThrowsTimeout_AndThrowsExternalServiceException() {
         long startTime = System.currentTimeMillis();
-        boolean result = ticketService.cancelTicket("mock_ticket_id");
+        assertThrows(ExternalServiceException.class,
+                () -> ticketService.cancelTicket("mock_ticket_id"),
+                "A timeout should throw ExternalServiceException");
         long endTime = System.currentTimeMillis();
 
         assertTrue((endTime - startTime) < 6000, "The request took too long! Timeout limit was bypassed.");
-        assertFalse(result, "A timeout exception should have been caught, returning false.");
     }
 }


### PR DESCRIPTION
Closes #196

- Created ExternalServiceException (RuntimeException subclass) thrown when external API returns -1
- ExternalPaymentService: processPayment and refund now throw ExternalServiceException instead of returning -1
- ExternalTicketService: issueTicket and cancelTicket now throw ExternalServiceException instead of returning -1/false
- PurchasedService: removed manual -1 checks, added dedicated ExternalServiceException catch to guarantee @Transactional rollback fires
- Updated ExternalServicesTimeoutTest to assertThrows instead of assertEquals(-1)
- Updated PurchasedServiceTest payment declined test to use doThrow
- Added ExternalServicesNegativeResponseTest with local HttpServer returning -1 to verify all gateway methods throw correctly