### PR TITLE
feat: handle external system anomalies and failures (#193)

### DIFF
--- a/src/main/java/com/ticketing/ticketapp/Appliction/PurchasedService.java
+++ b/src/main/java/com/ticketing/ticketapp/Appliction/PurchasedService.java
@@ -218,7 +218,11 @@ public class PurchasedService {
             }
 
             for (String ticketCode : order.getExternalTicketIds()) {
-                externalTicketService.cancelTicket(ticketCode);
+                try {
+                    externalTicketService.cancelTicket(ticketCode);
+                } catch (Exception e) {
+                    logger.warn("Failed to cancel external ticket {} during order cancellation: {}", ticketCode, e.getMessage());
+                }
             }
 
             for (String ticketId : order.getTicketsId()) {

--- a/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalPaymentService.java
+++ b/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalPaymentService.java
@@ -20,10 +20,6 @@ public class ExternalPaymentService implements IPaymentService {
         this.API_URL = apiUrl;
     }
 
-    private final HttpClient client = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(3))
-            .build();
-
     @Override
     public int processPayment(CreditCardDetails cardDetails, double amount, String currency) {
         try {
@@ -42,7 +38,9 @@ public class ExternalPaymentService implements IPaymentService {
                     .map(e -> e.getKey() + "=" + e.getValue())
                     .collect(Collectors.joining("&"));
 
-            HttpClient client = HttpClient.newHttpClient();
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(API_URL))
                     .header("Content-Type", "application/x-www-form-urlencoded")
@@ -51,9 +49,17 @@ public class ExternalPaymentService implements IPaymentService {
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new ExternalServiceException("Payment service returned HTTP " + response.statusCode());
+            }
+            String body = response.body();
+            if (body == null || body.isBlank()) {
+                throw new ExternalServiceException("Payment service returned empty response");
+            }
+            return Integer.parseInt(body.trim());
 
-            return Integer.parseInt(response.body().trim());
-
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (Exception e) {
             e.printStackTrace();
             return -1;
@@ -65,7 +71,9 @@ public class ExternalPaymentService implements IPaymentService {
         try {
             String requestBody = "action_type=refund&transaction_id=" + transactionId;
 
-            HttpClient client = HttpClient.newHttpClient();
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(API_URL))
                     .header("Content-Type", "application/x-www-form-urlencoded")
@@ -74,8 +82,17 @@ public class ExternalPaymentService implements IPaymentService {
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            return Integer.parseInt(response.body().trim());
+            if (response.statusCode() != 200) {
+                throw new ExternalServiceException("Payment refund service returned HTTP " + response.statusCode());
+            }
+            String body = response.body();
+            if (body == null || body.isBlank()) {
+                throw new ExternalServiceException("Payment refund service returned empty response");
+            }
+            return Integer.parseInt(body.trim());
 
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (HttpTimeoutException e) {
             System.err.println("[ExternalPaymentService] Timed Out! (Limit reached)");
             return -1;

--- a/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalServiceException.java
+++ b/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalServiceException.java
@@ -1,0 +1,11 @@
+package com.ticketing.ticketapp.Infastructure;
+
+public class ExternalServiceException extends RuntimeException {
+    public ExternalServiceException(String message) {
+        super(message);
+    }
+
+    public ExternalServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalTicketService.java
+++ b/src/main/java/com/ticketing/ticketapp/Infastructure/ExternalTicketService.java
@@ -21,10 +21,6 @@ public class ExternalTicketService implements IExternalTicketService {
         this.API_URL = apiUrl;
     }
 
-    private final HttpClient client = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(3))
-            .build();
-
     @Override
     public String issueTicket(String customerId, String eventId, String zone, int row, int seat) {
         try {
@@ -38,7 +34,9 @@ public class ExternalTicketService implements IExternalTicketService {
 
             System.out.println("[ExternalTicketService] issueTicket request: " + requestBody);
 
-            HttpClient client = HttpClient.newHttpClient();
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(API_URL))
                     .header("Content-Type", "application/x-www-form-urlencoded")
@@ -47,9 +45,18 @@ public class ExternalTicketService implements IExternalTicketService {
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            System.out.println("[ExternalTicketService] issueTicket response: " + response.body());
-            return response.body().trim();
+            if (response.statusCode() != 200) {
+                throw new ExternalServiceException("Ticket service returned HTTP " + response.statusCode() + " for issueTicket");
+            }
+            String body = response.body();
+            if (body == null || body.isBlank()) {
+                throw new ExternalServiceException("Ticket service returned empty response for issueTicket");
+            }
+            System.out.println("[ExternalTicketService] issueTicket response: " + body);
+            return body.trim();
 
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (HttpTimeoutException e) {
             System.err.println("[ExternalTicketService] issueTicket Timed Out!");
             return "-1";
@@ -67,7 +74,9 @@ public class ExternalTicketService implements IExternalTicketService {
 
             System.out.println("[ExternalTicketService] cancelTicket request: " + requestBody);
 
-            HttpClient client = HttpClient.newHttpClient();
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(3))
+                    .build();
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(API_URL))
                     .header("Content-Type", "application/x-www-form-urlencoded")
@@ -76,9 +85,18 @@ public class ExternalTicketService implements IExternalTicketService {
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            System.out.println("[ExternalTicketService] cancelTicket response: " + response.body());
-            return Integer.parseInt(response.body().trim()) == 1;
+            if (response.statusCode() != 200) {
+                throw new ExternalServiceException("Ticket service returned HTTP " + response.statusCode() + " for cancelTicket");
+            }
+            String body = response.body();
+            if (body == null || body.isBlank()) {
+                throw new ExternalServiceException("Ticket service returned empty response for cancelTicket");
+            }
+            System.out.println("[ExternalTicketService] cancelTicket response: " + body);
+            return Integer.parseInt(body.trim()) == 1;
 
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (HttpTimeoutException e) {
             System.err.println("[ExternalTicketService] cancelTicket Timed Out!");
             return false;


### PR DESCRIPTION
Closes #193

- Fixed connection timeout enforcement in ExternalPaymentService and ExternalTicketService — timeout was configured but never applied due to HttpClient.newHttpClient() shadowing the configured client
- Added response validation layer: checks HTTP status code (non-200 throws ExternalServiceException) and blank body before parsing, replacing confusing NumberFormatException with clear error messages
- Fixed cancelOrder best-effort fallback: each cancelTicket call now wrapped in try-catch so one failure logs a warning and continues instead of aborting remaining cancellations