### PR TITLE
feat: implement database connection recovery mechanisms (#192)

### DIFF
--- a/src/main/java/com/ticketing/ticketapp/Config/DatabaseHealthMonitor.java
+++ b/src/main/java/com/ticketing/ticketapp/Config/DatabaseHealthMonitor.java
@@ -1,0 +1,43 @@
+package com.ticketing.ticketapp.Config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+@Component
+public class DatabaseHealthMonitor {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseHealthMonitor.class);
+
+    private final DataSource dataSource;
+    private volatile boolean dbAvailable = true;
+
+    public DatabaseHealthMonitor(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Scheduled(fixedDelay = 30_000)
+    public void checkHealth() {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.createStatement().execute("SELECT 1");
+            if (!dbAvailable) {
+                logger.info("DatabaseHealthMonitor: database connection restored.");
+                dbAvailable = true;
+            }
+        } catch (SQLException e) {
+            if (dbAvailable) {
+                logger.error("DatabaseHealthMonitor: database connection lost: {}", e.getMessage());
+                dbAvailable = false;
+            }
+        }
+    }
+
+    public boolean isDbAvailable() {
+        return dbAvailable;
+    }
+}

--- a/src/main/java/com/ticketing/ticketapp/Controllers/GlobalExceptionHandler.java
+++ b/src/main/java/com/ticketing/ticketapp/Controllers/GlobalExceptionHandler.java
@@ -1,13 +1,20 @@
 package com.ticketing.ticketapp.Controllers;
 
 import com.ticketing.ticketapp.Domain.OwnerManagerTree.OwnerManagerException;
-import com.ticketing.ticketapp.Domain.PurchasedOrderAggregate.PurchaseOrderException; 
+import com.ticketing.ticketapp.Domain.PurchasedOrderAggregate.PurchaseOrderException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.CannotGetJdbcConnectionException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(OwnerManagerException.class)
     public ResponseEntity<String> handleOwnerManagerException(OwnerManagerException ex) {
@@ -19,5 +26,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(ex.getMessage());
     }
 
-    
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<String> handleDataAccessException(DataAccessException ex) {
+        if (ex instanceof CannotGetJdbcConnectionException) {
+            logger.error("Database unreachable: {}", ex.getMessage());
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body("Database is temporarily unavailable. Please try again later.");
+        }
+        logger.error("Database error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body("A database error occurred. Please try again later.");
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,20 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+
+# HikariCP connection pool — resilience settings
+# Validate each connection before use; stale/dead connections are evicted and replaced automatically
+spring.datasource.hikari.connection-test-query=SELECT 1
+# Periodic keepalive ping on idle connections to detect silent server-side drops
+spring.datasource.hikari.keepalive-time=60000
+# How long to wait for the pool to hand out a connection (ms)
+spring.datasource.hikari.connection-timeout=30000
+# How long to wait while validating a connection (ms)
+spring.datasource.hikari.validation-timeout=5000
+# Evict connections that have been idle longer than this (ms)
+spring.datasource.hikari.idle-timeout=600000
+# Recycle connections before PostgreSQL's server-side timeout can close them (ms)
+spring.datasource.hikari.max-lifetime=1800000
+# Keep at least 2 ready-to-use connections in the pool
+spring.datasource.hikari.minimum-idle=2
+spring.datasource.hikari.maximum-pool-size=10

--- a/src/test/java/Infastructure/DatabaseConnectionRecoveryTest.java
+++ b/src/test/java/Infastructure/DatabaseConnectionRecoveryTest.java
@@ -1,0 +1,107 @@
+package Infastructure;
+
+import com.ticketing.ticketapp.Config.DatabaseHealthMonitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.AbstractDataSource;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Simulates a database drop-off and reconnection without requiring a real DB.
+ * Uses a controllable fake DataSource backed by H2 to avoid JDK-module mocking
+ * restrictions, exercising the detect → outage → recovery lifecycle.
+ */
+public class DatabaseConnectionRecoveryTest {
+
+    /**
+     * Fake DataSource that can be switched between healthy and failing modes.
+     * Backed by H2 in-memory so real Connection objects are returned when healthy.
+     */
+    private static class ControllableDataSource extends AbstractDataSource {
+        private volatile boolean failing = false;
+
+        void setFailing(boolean fail) {
+            failing = fail;
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            if (failing) {
+                throw new SQLException("Simulated connection refused");
+            }
+            return DriverManager.getConnection("jdbc:h2:mem:healthtest;DB_CLOSE_DELAY=-1", "sa", "");
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) throws SQLException {
+            return getConnection();
+        }
+    }
+
+    private ControllableDataSource dataSource;
+    private DatabaseHealthMonitor monitor;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = new ControllableDataSource();
+        monitor = new DatabaseHealthMonitor(dataSource);
+    }
+
+    @Test
+    void detects_healthy_connection() {
+        dataSource.setFailing(false);
+
+        monitor.checkHealth();
+
+        assertTrue(monitor.isDbAvailable(), "Monitor should report DB as available when connection succeeds");
+    }
+
+    @Test
+    void detects_database_outage() {
+        dataSource.setFailing(true);
+
+        monitor.checkHealth();
+
+        assertFalse(monitor.isDbAvailable(), "Monitor should report DB as unavailable when connection fails");
+    }
+
+    @Test
+    void recovers_after_outage() {
+        // Phase 1: simulate outage
+        dataSource.setFailing(true);
+        monitor.checkHealth();
+        assertFalse(monitor.isDbAvailable());
+
+        // Phase 2: DB comes back
+        dataSource.setFailing(false);
+        monitor.checkHealth();
+        assertTrue(monitor.isDbAvailable(), "Monitor should report DB as available once connection is restored");
+    }
+
+    @Test
+    void repeated_outage_does_not_change_state() {
+        dataSource.setFailing(true);
+        monitor.checkHealth();
+        assertFalse(monitor.isDbAvailable());
+
+        monitor.checkHealth();
+        assertFalse(monitor.isDbAvailable(), "Repeated failures should keep state as unavailable");
+    }
+
+    @Test
+    void repeated_healthy_checks_keep_state_available() {
+        dataSource.setFailing(false);
+
+        monitor.checkHealth();
+        assertTrue(monitor.isDbAvailable());
+
+        monitor.checkHealth();
+        assertTrue(monitor.isDbAvailable(), "Repeated successes should keep state as available");
+    }
+}


### PR DESCRIPTION
Closes #192

- Added HikariCP connection pool resilience properties (connection-test-query, keepalive, timeouts, pool sizing) to application.properties
- Added DataAccessException handler to GlobalExceptionHandler returning HTTP 503 with clear user-facing messages
- Created DatabaseHealthMonitor component that probes the DB every 30 seconds and logs state transitions
- Added DatabaseConnectionRecoveryTest with 5 tests covering healthy, outage, recovery, repeated failures, and repeated healthy checks